### PR TITLE
Add WCSimReader tool (and testing toolchain WCSimReaderTest)

### DIFF
--- a/DataModel/DataModel.h
+++ b/DataModel/DataModel.h
@@ -68,13 +68,18 @@ class DataModel {
 
   zmq::context_t* context;
 
-  std::vector<SubSample> Samples;
+  std::vector<SubSample> IDSamples;
   std::vector<SubSample> ODSamples;
 
   std::vector<PMTInfo> IDGeom;
   std::vector<PMTInfo> ODGeom;
 
   bool triggeroutput;
+
+  double IDPMTDarkRate;
+  double ODPMTDarkRate;
+  double IDNPMTs;
+  double ODNPMTs;
   
   WCSimRootOptions WCSimOpt;
   WCSimRootEvent   WCSimEvt;

--- a/DataModel/DataModel.h
+++ b/DataModel/DataModel.h
@@ -78,8 +78,8 @@ class DataModel {
 
   double IDPMTDarkRate;
   double ODPMTDarkRate;
-  double IDNPMTs;
-  double ODNPMTs;
+  int IDNPMTs;
+  int ODNPMTs;
   
   WCSimRootOptions WCSimOpt;
   WCSimRootEvent   WCSimEvt;

--- a/DataModel/DataModel.h
+++ b/DataModel/DataModel.h
@@ -87,6 +87,8 @@ class DataModel {
 
   bool IsMC;
 
+  std::vector<std::string> WCSimFiles;
+
  private:
 
 

--- a/DataModel/DataModel.h
+++ b/DataModel/DataModel.h
@@ -7,6 +7,10 @@
 
 //#include "TTree.h"
 
+#include "WCSimRootOptions.hh"
+#include "WCSimRootEvent.hh"
+#include "WCSimRootGeom.hh"
+
 #include "Store.h"
 #include "BoostStore.h"
 #include "Logging.h"
@@ -22,10 +26,15 @@ class SubSample{
     m_PMTid=PMTid;
     m_time=time;
   }
+  SubSample(std::vector<int> PMTid, std::vector<int> time, std::vector<int> charge) {
+    m_PMTid  = PMTid;
+    m_time   = time;
+    m_charge = charge;
+  }
 
   std::vector<int> m_PMTid;
   std::vector<int> m_time;
-
+  std::vector<int> m_charge;
 };
 
 class DataModel {
@@ -50,6 +59,9 @@ class DataModel {
   std::vector<SubSample> Samples;
   bool triggeroutput;
   
+  WCSimRootOptions WCSimOpt;
+  WCSimRootEvent   WCSimEvt;
+  WCSimRootGeom    WCSimGeo;
 
 
  private:

--- a/DataModel/DataModel.h
+++ b/DataModel/DataModel.h
@@ -37,6 +37,18 @@ class SubSample{
   std::vector<int> m_charge;
 };
 
+class PMTInfo{
+ public:
+  PMTInfo(int tubeno, float x, float y, float z) {
+    m_tubeno = tubeno;
+    m_x = x;
+    m_y = y;
+    m_z = z;
+  }
+  int m_tubeno;
+  float m_x, m_y, m_z;
+};
+
 class DataModel {
 
 
@@ -57,6 +69,11 @@ class DataModel {
   zmq::context_t* context;
 
   std::vector<SubSample> Samples;
+  std::vector<SubSample> ODSamples;
+
+  std::vector<PMTInfo> IDGeom;
+  std::vector<PMTInfo> ODGeom;
+
   bool triggeroutput;
   
   WCSimRootOptions WCSimOpt;

--- a/DataModel/DataModel.h
+++ b/DataModel/DataModel.h
@@ -85,6 +85,7 @@ class DataModel {
   WCSimRootEvent   WCSimEvt;
   WCSimRootGeom    WCSimGeo;
 
+  bool IsMC;
 
  private:
 

--- a/Makefile
+++ b/Makefile
@@ -22,17 +22,23 @@ MyToolsLib =
 MyToolsIncludeGPU = $(MyToolsInclude) $(CUDAINC)
 MyToolsLibGPU = $(MyToolsLib) $(CUDALIB)
 
+RootInclude := -I$(shell root-config --incdir)
+RootLib     := $(shell root-config --libs)
+
+WCSimInclude = -I$(WCSIMDIR)/include
+WCSimLib     = -L$(WCSIMDIR) -lWCSimRoot
+
 all: lib/libStore.so lib/libLogging.so lib/libDataModel.so include/Tool.h lib/libMyTools.so lib/libServiceDiscovery.so lib/libToolChain.so main RemoteControl  NodeDaemon
 
 GPU: lib/libStore.so lib/libLogging.so lib/libDataModel.so include/Tool.h lib/libMyToolsGPU.so lib/libServiceDiscovery.so lib/libToolChain.so mainGPU RemoteControl NodeDaemon
 
 main: src/main.cpp | lib/libMyTools.so lib/libStore.so lib/libLogging.so lib/libToolChain.so lib/libDataModel.so lib/libServiceDiscovery.so
 	@echo "\n*************** Making " $@ "****************"
-	g++ -g src/main.cpp -o main -I include -L lib -lStore -lMyTools -lToolChain -lDataModel -lLogging -lServiceDiscovery -lpthread $(DataModelInclude) $(MyToolsInclude)  $(MyToolsLib) $(ZMQLib) $(ZMQInclude)  $(BoostLib) $(BoostInclude)
+	g++ -g src/main.cpp -o main -I include -L lib -lStore -lMyTools -lToolChain -lDataModel -lLogging -lServiceDiscovery -lpthread $(DataModelInclude) $(MyToolsInclude)  $(MyToolsLib) $(ZMQLib) $(ZMQInclude)  $(BoostLib) $(BoostInclude) $(RootLib) $(RootInclude) $(WCSimLib) $(WCSimInclude)
 
 mainGPU: src/main.cpp UserTools/CUDA/GPU_link.o | lib/libMyToolsGPU.so lib/libStore.so lib/libLogging.so lib/libToolChain.so lib/libDataModel.so lib/libServiceDiscovery.so
 	@echo "\n*************** Making " $@ "****************"
-	g++ -g src/main.cpp UserTools/CUDA/GPU_link.o -o main -I include -L lib -lStore -lMyToolsGPU  -lMyTools -lToolChain -lDataModel -lLogging -lServiceDiscovery -lpthread $(DataModelInclude) $(MyToolsIncludeGPU)  $(MyToolsLibGPU) $(ZMQLib) $(ZMQInclude)  $(BoostLib) $(BoostInclude)
+	g++ -g src/main.cpp UserTools/CUDA/GPU_link.o -o main -I include -L lib -lStore -lMyToolsGPU  -lMyTools -lToolChain -lDataModel -lLogging -lServiceDiscovery -lpthread $(DataModelInclude) $(MyToolsIncludeGPU)  $(MyToolsLibGPU) $(ZMQLib) $(ZMQInclude)  $(BoostLib) $(BoostInclude) $(RootLib) $(RootInclude) $(WCSimLib) $(WCSimInclude)
 
 
 lib/libStore.so: $(ToolDAQPath)/ToolDAQFramework/src/Store/*
@@ -74,7 +80,7 @@ lib/libMyTools.so: UserTools/*/* UserTools/* | include/Tool.h lib/libDataModel.s
 	@echo "\n*************** Making " $@ "****************"
 	cp UserTools/*/*.h include/
 	cp UserTools/Factory/*.h include/
-	g++ -g -fPIC -shared  UserTools/Factory/Factory.cpp -I include -L lib -lStore -lDataModel -lLogging -o lib/libMyTools.so $(MyToolsInclude) $(MyToolsLib) $(DataModelInclude) $(ZMQLib) $(ZMQInclude) $(BoostLib) $(BoostInclude)
+	g++ -g -fPIC -shared  UserTools/Factory/Factory.cpp -I include -L lib -lStore -lDataModel -lLogging -o lib/libMyTools.so $(MyToolsInclude) $(MyToolsLib) $(DataModelInclude) $(ZMQLib) $(ZMQInclude) $(BoostLib) $(BoostInclude) $(RootLib) $(RootInclude) $(WCSimLib) $(WCSimInclude)
 
 lib/libMyToolsGPU.so: UserTools/*/* UserTools/* UserTools/CUDA/GPU_link.o | include/Tool.h lib/libDataModel.so lib/libLogging.so lib/libStore.so
 	@echo "\n*************** Making " $@ "****************"

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ lib/libToolChain.so: $(ToolDAQPath)/ToolDAQFramework/src/ToolChain/* | lib/libLo
 	@echo "\n*************** Making " $@ "****************"
 	cp $(ToolDAQPath)/ToolDAQFramework/UserTools/Factory/*.h include/
 	cp $(ToolDAQPath)/ToolDAQFramework/src/ToolChain/*.h include/
-	g++ -g -fPIC -shared $(ToolDAQPath)/ToolDAQFramework/src/ToolChain/ToolChain.cpp -I include -lpthread -L lib -lStore -lDataModel -lServiceDiscovery -lMyTools -lLogging -o lib/libToolChain.so $(DataModelInclude) $(ZMQLib) $(ZMQInclude) $(MyToolsInclude)  $(BoostLib) $(BoostInclude)
+	g++ -g -fPIC -shared $(ToolDAQPath)/ToolDAQFramework/src/ToolChain/ToolChain.cpp -I include -lpthread -L lib -lStore -lDataModel -lServiceDiscovery -lMyTools -lLogging -o lib/libToolChain.so $(DataModelInclude) $(ZMQLib) $(ZMQInclude) $(MyToolsInclude)  $(BoostLib) $(BoostInclude) $(RootLib) $(RootInclude) $(WCSimLib) $(WCSimInclude)
 
 
 
@@ -74,7 +74,7 @@ clean:
 lib/libDataModel.so: DataModel/* lib/libLogging.so | lib/libStore.so
 	@echo "\n*************** Making " $@ "****************"
 	cp DataModel/*.h include/
-	g++ -g -fPIC -shared DataModel/*.cpp -I include -L lib -lStore  -lLogging  -o lib/libDataModel.so $(DataModelInclude) $(DataModelLib) $(ZMQLib) $(ZMQInclude)  $(BoostLib) $(BoostInclude)
+	g++ -g -fPIC -shared DataModel/*.cpp -I include -L lib -lStore  -lLogging  -o lib/libDataModel.so $(DataModelInclude) $(DataModelLib) $(ZMQLib) $(ZMQInclude)  $(BoostLib) $(BoostInclude) $(RootLib) $(RootInclude) $(WCSimLib) $(WCSimInclude)
 
 lib/libMyTools.so: UserTools/*/* UserTools/* | include/Tool.h lib/libDataModel.so lib/libLogging.so lib/libStore.so
 	@echo "\n*************** Making " $@ "****************"

--- a/UserTools/Factory/Factory.cpp
+++ b/UserTools/Factory/Factory.cpp
@@ -9,7 +9,8 @@ if (tool=="DummyTool") ret=new DummyTool;
 if (tool=="TriggerOutput") ret=new TriggerOutput;
 if (tool=="WCSimASCIReader") ret=new WCSimASCIReader;
 if (tool=="nhits") ret=new nhits;
-  if (tool=="test_vertices") ret=new test_vertices;
+if (tool=="test_vertices") ret=new test_vertices;
+  if (tool=="WCSimReader") ret=new WCSimReader;
 return ret;
 }
 

--- a/UserTools/Unity.cpp
+++ b/UserTools/Unity.cpp
@@ -3,3 +3,4 @@
 #include "WCSimASCIReader/WCSimASCIReader.cpp"
 #include "nhits/nhits.cpp"
 #include "test_vertices/test_vertices.cpp"
+#include "WCSimReader/WCSimReader.cpp"

--- a/UserTools/WCSimASCIReader/WCSimASCIReader.cpp
+++ b/UserTools/WCSimASCIReader/WCSimASCIReader.cpp
@@ -35,7 +35,7 @@ bool WCSimASCIReader::Execute(){
       }
 
     SubSample tmpsb(PMTid,time);
-    m_data->Samples.push_back(tmpsb);
+    m_data->IDSamples.push_back(tmpsb);
     
     data.close();
 

--- a/UserTools/WCSimReader/README.md
+++ b/UserTools/WCSimReader/README.md
@@ -1,0 +1,27 @@
+# WCSimReader
+
+WCSimReader reads in WCSim root files
+
+## Data
+
+WCSimReader
+* reads in WCSim root files
+* adds to the transient data model
+  * PMT geometry (ID, position, angle)
+  * Digitised hit information (charge, time, ID)
+  * WCSim pass through information
+
+
+## Configuration
+
+Describe any configuration variables for WCSimReader.
+
+```
+infile /path/to/file(s)
+filelist /path/to/txt/file/list
+nevents N
+```
+
+* `infile` can use wildcards to pickup multiple files
+* `filelist` can also contain wildcards
+* `nevents` will read only this number of events. If `N <= 0`, read all. If `N > number of available events`, read all.

--- a/UserTools/WCSimReader/README.md
+++ b/UserTools/WCSimReader/README.md
@@ -8,9 +8,31 @@ WCSimReader
 * reads in WCSim root files
 * adds to the transient data model
   * PMT geometry (ID, position, angle)
+    Stored in a `vector` of `PMTInfo`
+    * `IDGeom` ID PMTs
+    * `ODGeom` OD PMTs
   * Digitised hit information (charge, time, ID)
+    Stored in a `vector` of `SubSample`
+    * `IDSamples` for ID digits
+    * `ODSamples` for OD digits
+  * Number of PMTs
+    Stored as an `int`
+    * `IDNPMTs` for ID number of PMTs
+    * `ODNPMTs` for OD number of PMTs
+  * PMT dark rate
+    Stored as `double`
+    * `IDPMTDarkRate` for ID PMT dark rate
+    * `ODPMTDarkRate` for OD PMT dark rate
+  * Flag to state whether the "data" is from Monte Carlo
+    Stored as `bool`
+    * `IsMC`
+  * List of input WCSim files.
+    Note that these are the files after the wildcard expansion.
+    Stored in a `vector` of `string`
+    * `WCSimFiles`
   * WCSim pass through information
-
+    This isn't implemented yet
+    
 
 ## Configuration
 
@@ -20,8 +42,10 @@ Describe any configuration variables for WCSimReader.
 infile /path/to/file(s)
 filelist /path/to/txt/file/list
 nevents N
+verbose LEVEL
 ```
 
-* `infile` can use wildcards to pickup multiple files
-* `filelist` can also contain wildcards
+* `infile` File path to WCSim root file. Can use wildcards to pickup multiple files
+* `filelist` File path to a text file with a filepath to a WCSim root file on each line. Can also contain wildcards
 * `nevents` will read only this number of events. If `N <= 0`, read all. If `N > number of available events`, read all.
+* `verbose` Verbosity level. Runs from 0 (low verbosity) to 9 (high verbosity)

--- a/UserTools/WCSimReader/WCSimReader.cpp
+++ b/UserTools/WCSimReader/WCSimReader.cpp
@@ -48,6 +48,7 @@ bool WCSimReader::Initialise(std::string configfile, DataModel &data){
   fChainEvent->SetBranchAddress("wcsimrootevent",   &fWCEvt);
   fWCGeo = new WCSimRootGeom();
   fChainGeom ->SetBranchAddress("wcsimrootgeom",    &fWCGeo);
+  //TODO OD digits
 
   //ensure that the geometry & options are the same for each file
   if(!CompareTree(fChainOpt))
@@ -66,6 +67,19 @@ bool WCSimReader::Initialise(std::string configfile, DataModel &data){
   m_data->WCSimOpt = *fWCOpt;
   m_data->WCSimEvt = *fWCEvt;
   m_data->WCSimGeo = *fWCGeo;
+
+  //store the PMT locations
+  /*
+  for(int ipmt = 0; ipmt < fWCGeo->GetWCNumPMT(); ipmt++) {
+    WCSimRootPMT pmt = fWCGeo->GetPMT(ipmt);
+    PMTInfo pmt_light(pmt.GetTubeNo(), pmt.GetPosition(0), pmt.GetPosition(1), pmt.GetPosition(2));
+    m_data->IDGeom.push_back(pmt_light);
+    //TODO differentiate OD/ID PMTs
+  }//ipmt
+  */
+
+  //store the relevant options
+  //TODO dark noise
 
   return true;
 }

--- a/UserTools/WCSimReader/WCSimReader.cpp
+++ b/UserTools/WCSimReader/WCSimReader.cpp
@@ -1,5 +1,9 @@
 #include "WCSimReader.h"
 
+using std::cout;
+using std::cerr;
+using std::endl;
+
 WCSimReader::WCSimReader():Tool(){}
 
 
@@ -10,17 +14,100 @@ bool WCSimReader::Initialise(std::string configfile, DataModel &data){
 
   m_data= &data;
 
+  //config reading
+  if(! m_variables.Get("nevents",  fNEvents) ) {
+    cout << "nevents configuration not found. Reading all events" << endl;
+    fNEvents = -1;
+  }
+  if(! (m_variables.Get("infile",   fInFile) ||
+	m_variables.Get("filelist", fFileList))) {
+    cerr << "You must use one of the following options: "
+	 << " infile filelist" << endl;
+    return false;
+  }
+     
+  cout << "fNEvents  \t" << fNEvents  << endl;
+  cout << "fInFile   \t" << fInFile   << endl;
+  cout << "fFileList \t" << fFileList << endl;
+
+  //open the trees
+  fChainOpt   = new TChain("wcsimRootOptionsT");
+  fChainEvent = new TChain("wcsimT");
+  fChainGeom  = new TChain("wcsimGeoT");
+
+  if(!ReadTree(fChainOpt))
+    return false;
+  if(!ReadTree(fChainEvent))
+    return false;
+  if(!ReadTree(fChainGeom))
+    return false;
+
+  //ensure that the geometry & options are the same for each file
+  if(!CompareTree(fChainOpt))
+    return false;
+  if(!CompareTree(fChainGeom))
+    return false;
+
+  //set number of events
+  if(fNEvents <= 0)
+    fNEvents = fChainEvent->GetEntries();
+  else if (fNEvents > fChainEvent->GetEntries())
+    fNEvents = fChainEvent->GetEntries();
+  fCurrEvent = 0;
+
   return true;
 }
 
+bool WCSimReader::ReadTree(TChain * chain) {
+  //use InFile
+  if(fInFile.size()) { 
+    if(! chain->Add(fInFile.c_str(), -1)) {
+      cerr << "Could not load tree: " << chain->GetName()
+	   << " in file(s): " << fInFile << endl;
+      return false;
+    }
+    cout << "Loaded tree: " << chain->GetName()
+	 << " from file(s): " << fInFile
+	 << " with: " << chain->GetEntries()
+	 << " entries" << endl;
+    return true;
+  }
+  //use FileList
+  else if(fFileList.size()) {
+    cerr << "FileList not implemented" << endl;
+    return false;
+  }
+  else {
+    cerr << "Must use one of the following options: "
+	 << " infile filelist" << endl;
+    return false;
+  }
+}
+
+bool WCSimReader::CompareTree(TChain * chain)
+{
+  cerr << "This function to ensure that the geometry (and at least some of the options tree) are identical is not yet implemented" << endl;
+  return true;
+}
 
 bool WCSimReader::Execute(){
+  cout << "Event " << fCurrEvent << " of " << fNEvents << endl;
+
+
+  //and finally, increment event counter
+  fCurrEvent++;
+  if(fCurrEvent > fNEvents)
+    return false;
 
   return true;
 }
 
 
 bool WCSimReader::Finalise(){
+
+  delete fChainOpt;
+  delete fChainEvent;
+  delete fChainGeom;
 
   return true;
 }

--- a/UserTools/WCSimReader/WCSimReader.cpp
+++ b/UserTools/WCSimReader/WCSimReader.cpp
@@ -88,6 +88,8 @@ bool WCSimReader::Initialise(std::string configfile, DataModel &data){
   //m_data->WCSimGeo = *fWCGeo;
 
   //store the relevant options
+  m_data->IsMC = true;
+  //geometry
   m_data->IDPMTDarkRate = fWCOpt->GetPMTDarkRate();
   m_data->IDNPMTs = fWCGeo->GetWCNumPMT();
   cerr << "OD Dark rate is not current stored. TODO add when WCSim #246 is merged" << endl;

--- a/UserTools/WCSimReader/WCSimReader.cpp
+++ b/UserTools/WCSimReader/WCSimReader.cpp
@@ -1,0 +1,26 @@
+#include "WCSimReader.h"
+
+WCSimReader::WCSimReader():Tool(){}
+
+
+bool WCSimReader::Initialise(std::string configfile, DataModel &data){
+
+  if(configfile!="")  m_variables.Initialise(configfile);
+  //m_variables.Print();
+
+  m_data= &data;
+
+  return true;
+}
+
+
+bool WCSimReader::Execute(){
+
+  return true;
+}
+
+
+bool WCSimReader::Finalise(){
+
+  return true;
+}

--- a/UserTools/WCSimReader/WCSimReader.cpp
+++ b/UserTools/WCSimReader/WCSimReader.cpp
@@ -28,9 +28,10 @@ bool WCSimReader::Initialise(std::string configfile, DataModel &data){
 
   ss << "INFO: fNEvents  \t" << fNEvents;
   StreamToLog(INFO);
-  ss << "INFO: fInFile   \t" << fInFile;
-  StreamToLog(INFO);
-  ss << "INFO: fFileList \t" << fFileList;
+  if(fInFile.size())
+    ss << "INFO: fInFile   \t" << fInFile;
+  else
+    ss << "INFO: fFileList \t" << fFileList;
   StreamToLog(INFO);
 
   //open the trees
@@ -121,7 +122,8 @@ bool WCSimReader::AddTreeToChain(const char * fname, TChain * chain) {
   }
   ss << "INFO: Loaded tree: " << chain->GetName()
      << " from file(s): " << fname
-     << " with: " << chain->GetEntries()
+     << " Chain: " << chain->GetName()
+     << " now has " << chain->GetEntries()
      << " entries";
   StreamToLog(INFO);
   return true;

--- a/UserTools/WCSimReader/WCSimReader.cpp
+++ b/UserTools/WCSimReader/WCSimReader.cpp
@@ -47,9 +47,7 @@ bool WCSimReader::Initialise(std::string configfile, DataModel &data){
   fChainOpt->GetEntry(0);
   fWCEvtID = new WCSimRootEvent();
   fChainEvent->SetBranchAddress("wcsimrootevent",   &fWCEvtID);
-  cerr << "Waiting for WCSim PR #251 to be able to save OD digits" << endl;
-  if(false) {
-  //if(fWCOpt->GetGeomHasOD()) { // TODO uncomment this after WCSim 251 merged
+  if(fWCOpt->GetGeomHasOD()) {
     cout << "The geometry has an OD. Will add OD digits to m_data" << endl;
     fWCEvtOD = new WCSimRootEvent();
     fChainEvent->SetBranchAddress("wcsimrootevent_OD",   &fWCEvtOD);

--- a/UserTools/WCSimReader/WCSimReader.cpp
+++ b/UserTools/WCSimReader/WCSimReader.cpp
@@ -96,9 +96,8 @@ bool WCSimReader::Initialise(std::string configfile, DataModel &data){
   //file names
   TObjArray * rootfiles = fChainEvent->GetListOfFiles();
   for(int ifile = 0; ifile < rootfiles->GetEntries(); ifile++) {
-    fWCSimFiles.push_back(rootfiles->At(ifile)->GetTitle());
+    m_data->WCSimFiles.push_back(rootfiles->At(ifile)->GetTitle());
   }
-  m_data->WCSimFiles = fWCSimFiles;
   //geometry
   m_data->IDPMTDarkRate = fWCOpt->GetPMTDarkRate();
   m_data->IDNPMTs = fWCGeo->GetWCNumPMT();

--- a/UserTools/WCSimReader/WCSimReader.h
+++ b/UserTools/WCSimReader/WCSimReader.h
@@ -1,0 +1,29 @@
+#ifndef WCSimReader_H
+#define WCSimReader_H
+
+#include <string>
+#include <iostream>
+
+#include "Tool.h"
+
+class WCSimReader: public Tool {
+
+
+ public:
+
+  WCSimReader();
+  bool Initialise(std::string configfile,DataModel &data);
+  bool Execute();
+  bool Finalise();
+
+
+ private:
+
+
+
+
+
+};
+
+
+#endif

--- a/UserTools/WCSimReader/WCSimReader.h
+++ b/UserTools/WCSimReader/WCSimReader.h
@@ -27,7 +27,8 @@ class WCSimReader: public Tool {
  private:
   //methods used in Initialise
   bool ReadTree(TChain * chain);
-  bool CompareTree(TChain * chain);
+  bool CompareTree(TChain * chain, int mode);
+  template <typename T> bool CompareVariable(T v1, T v2, const char * tag);
 
   //methods used in Execute
   SubSample GetDigits();
@@ -37,9 +38,11 @@ class WCSimReader: public Tool {
   TChain * fChainGeom;
 
   WCSimRootOptions * fWCOpt;
+  WCSimRootOptions * fWCOpt_Store;
   WCSimRootEvent   * fWCEvtID;
   WCSimRootEvent   * fWCEvtOD;
   WCSimRootGeom    * fWCGeo;
+  WCSimRootGeom    * fWCGeo_Store;
   WCSimRootTrigger * fEvt;
 
   long int fCurrEvent;

--- a/UserTools/WCSimReader/WCSimReader.h
+++ b/UserTools/WCSimReader/WCSimReader.h
@@ -4,6 +4,12 @@
 #include <string>
 #include <iostream>
 
+#include "WCSimRootOptions.hh"
+#include "WCSimRootEvent.hh"
+#include "WCSimRootGeom.hh"
+
+#include "TChain.h"
+
 #include "Tool.h"
 
 class WCSimReader: public Tool {
@@ -18,10 +24,18 @@ class WCSimReader: public Tool {
 
 
  private:
+  bool ReadTree(TChain * chain);
+  bool CompareTree(TChain * chain);
 
+  TChain * fChainOpt;
+  TChain * fChainEvent;
+  TChain * fChainGeom;
 
+  long int fCurrEvent;
+  long int fNEvents;
 
-
+  std::string fInFile;
+  std::string fFileList;
 
 };
 

--- a/UserTools/WCSimReader/WCSimReader.h
+++ b/UserTools/WCSimReader/WCSimReader.h
@@ -47,6 +47,17 @@ class WCSimReader: public Tool {
 
   std::string fInFile;
   std::string fFileList;
+
+  int verbose;
+
+  std::stringstream ss;
+
+  void StreamToLog(int level) {
+    Log(ss.str(), level, verbose);
+    ss.str("");
+  }
+
+  enum LogLevel {FATAL=-1, ERROR=0, WARN=1, INFO=2, DEBUG1=3, DEBUG2=4, DEBUG3=5};
 };
 
 

--- a/UserTools/WCSimReader/WCSimReader.h
+++ b/UserTools/WCSimReader/WCSimReader.h
@@ -27,6 +27,7 @@ class WCSimReader: public Tool {
  private:
   //methods used in Initialise
   bool ReadTree(TChain * chain);
+  bool AddTreeToChain(const char * fname, TChain * chain);
   bool CompareTree(TChain * chain, int mode);
   template <typename T> bool CompareVariable(T v1, T v2, const char * tag);
 
@@ -50,6 +51,7 @@ class WCSimReader: public Tool {
 
   std::string fInFile;
   std::string fFileList;
+  std::vector<std::string> fWCSimFiles;
 
   int verbose;
 

--- a/UserTools/WCSimReader/WCSimReader.h
+++ b/UserTools/WCSimReader/WCSimReader.h
@@ -31,6 +31,11 @@ class WCSimReader: public Tool {
   TChain * fChainEvent;
   TChain * fChainGeom;
 
+  WCSimRootOptions * fWCOpt;
+  WCSimRootEvent   * fWCEvt;
+  WCSimRootGeom    * fWCGeo;
+  WCSimRootTrigger * fEvt;
+
   long int fCurrEvent;
   long int fNEvents;
 

--- a/UserTools/WCSimReader/WCSimReader.h
+++ b/UserTools/WCSimReader/WCSimReader.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <iostream>
+#include <sstream>
 
 #include "WCSimRootOptions.hh"
 #include "WCSimRootEvent.hh"
@@ -24,15 +25,20 @@ class WCSimReader: public Tool {
 
 
  private:
+  //methods used in Initialise
   bool ReadTree(TChain * chain);
   bool CompareTree(TChain * chain);
+
+  //methods used in Execute
+  SubSample GetDigits();
 
   TChain * fChainOpt;
   TChain * fChainEvent;
   TChain * fChainGeom;
 
   WCSimRootOptions * fWCOpt;
-  WCSimRootEvent   * fWCEvt;
+  WCSimRootEvent   * fWCEvtID;
+  WCSimRootEvent   * fWCEvtOD;
   WCSimRootGeom    * fWCGeo;
   WCSimRootTrigger * fEvt;
 
@@ -41,7 +47,6 @@ class WCSimReader: public Tool {
 
   std::string fInFile;
   std::string fFileList;
-
 };
 
 

--- a/UserTools/nhits/nhits.cpp
+++ b/UserTools/nhits/nhits.cpp
@@ -61,17 +61,17 @@ bool nhits::Execute(){
 
   //do stuff with m_data->Samples
 
-  printf(" qqq data samples size %d \n", m_data->Samples.size());
+  printf(" qqq data samples size %d \n", m_data->IDSamples.size());
 
-  for( std::vector<SubSample>::const_iterator is=m_data->Samples.begin(); is!=m_data->Samples.end(); ++is){
+  for( std::vector<SubSample>::const_iterator is=m_data->IDSamples.begin(); is!=m_data->IDSamples.end(); ++is){
 #ifdef GPU   
   //  the_output =   GPU_daq::nhits_execute();
   the_output =   GPU_daq::nhits_execute(is->m_PMTid, is->m_time);
-  printf(" qqq qqq look at %d of size %d \n", is - m_data->Samples.begin(), m_data->Samples.size());
+  printf(" qqq qqq look at %d of size %d \n", is - m_data->IDSamples.begin(), m_data->IDSamples.size());
 #endif
   }
 
-  //  the_output = CUDAFunction(m_data->Samples.at(0).m_PMTid, m_data->Samples.at(0).m_time);
+  //  the_output = CUDAFunction(m_data->IDSamples.at(0).m_PMTid, m_data->IDSamples.at(0).m_time);
   m_data->triggeroutput=(bool)the_output;
 
 

--- a/WCSimReaderTest
+++ b/WCSimReaderTest
@@ -1,0 +1,1 @@
+configfiles/WCSimReaderTest/ToolChainConfig

--- a/configfiles/WCSimReaderTest/README.md
+++ b/configfiles/WCSimReaderTest/README.md
@@ -1,0 +1,25 @@
+# Configure files
+
+***********************
+#Description
+**********************
+
+Configure files are simple text files for passing variables to the Tools.
+
+Text files are read by the Store class (src/Store) and automatically asigned to an internal map for the relavent Tool to use.
+
+
+************************
+#Usage
+************************
+
+Any line starting with a "#" will be ignored by the Store, as will blank lines.
+
+Variables should be stored one per line as follows:
+
+
+Name Value #Comments 
+
+
+Note: Only one value is permitted per name and they are stored in a string stream and templated cast back to the type given.
+

--- a/configfiles/WCSimReaderTest/ToolChainConfig
+++ b/configfiles/WCSimReaderTest/ToolChainConfig
@@ -1,0 +1,23 @@
+#ToolChain dynamic setup file
+
+##### Runtime Paramiters #####
+verbose 1 ## Verbosity level of ToolChain
+error_level 0 # 0= do not exit, 1= exit on unhandeled errors only, 2= exit on unhandeled errors and handeled errors
+attempt_recover 1 ## 1= will attempt to finalise if an execute fails
+
+###### Logging #####
+log_mode Interactive # Interactive=cout , Remote= remote logging system "serservice_name Remote_Logging" , Local = local file log;
+log_local_path ./log
+log_service LogStore
+
+###### Service discovery ##### Ignore these settings for local analysis
+service_publish_sec -1
+service_kick_sec -1
+
+##### Tools To Add #####
+Tools_File configfiles/WCSimReaderTest/ToolsConfig  ## list of tools to run and their config files
+
+##### Run Type #####
+Inline -1 ## number of Execute steps in program, -1 infinite loop that is ended by user 
+Interactive 0 ## set to 1 if you want to run the code interactively
+

--- a/configfiles/WCSimReaderTest/ToolsConfig
+++ b/configfiles/WCSimReaderTest/ToolsConfig
@@ -1,3 +1,1 @@
-test1 DummyTool configfiles/DummyToolConfig
-test2 DummyTool configfiles/DummyToolConfig
 wcsim1 WCSimReader configfiles/WCSimReaderToolConfig

--- a/configfiles/WCSimReaderTest/ToolsConfig
+++ b/configfiles/WCSimReaderTest/ToolsConfig
@@ -1,1 +1,1 @@
-wcsim1 WCSimReader configfiles/WCSimReaderToolConfig
+wcsim1 WCSimReader configfiles/WCSimReaderTest/WCSimReaderToolConfig

--- a/configfiles/WCSimReaderTest/ToolsConfig
+++ b/configfiles/WCSimReaderTest/ToolsConfig
@@ -1,0 +1,3 @@
+test1 DummyTool configfiles/DummyToolConfig
+test2 DummyTool configfiles/DummyToolConfig
+wcsim1 WCSimReader configfiles/WCSimReaderToolConfig

--- a/configfiles/WCSimReaderTest/WCSimReaderToolConfig
+++ b/configfiles/WCSimReaderTest/WCSimReaderToolConfig
@@ -2,3 +2,4 @@
 
 infile $WCSIMDIR/wcsim.root
 nevents -1
+verbose 3

--- a/configfiles/WCSimReaderTest/WCSimReaderToolConfig
+++ b/configfiles/WCSimReaderTest/WCSimReaderToolConfig
@@ -1,0 +1,4 @@
+# Dummy config file
+
+infile $WCSIMDIR/wcsim.root
+nevents -1

--- a/configfiles/WCSimReaderTest/WCSimReaderToolConfig
+++ b/configfiles/WCSimReaderTest/WCSimReaderToolConfig
@@ -1,5 +1,6 @@
 # Dummy config file
 
 infile $WCSIMDIR/wcsim.root
+#filelist wcsimfilelist
 nevents -1
 verbose 3


### PR DESCRIPTION
This tool takes WCSim files and formats the data (predominantly digits and PMT positions) to store in the transient data model. 
Makefile was modified to add the WCSim and ROOT libs/includes
What's not implemented:
* Chopping the WCSim events into specific time slices. This requires HK software group discussion as dark noise makes this non-trivial.
* Saving the WCSim pass through information. Again this requires discussion in the software group as to what the output of TriggerApplication should be (i.e. whether it uses WCSim classes, the flat tree structure in the E61 branch, or something else)
* Check for same geometry in every input file (requires changes to WCSim - copy constructor implemented for WCSimRootGeom, a WCSimRootGeom comparison operator makes sense too)