### PR TITLE
Tidy up after validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+main
+lib/*.so
+
+#files from the ToolDAQ framework
+ToolDAQ/
+include/*.h
+NodeDaemon
+RemoteControl
+
+#temp files
+*~ 
+.#*

--- a/DataModel/SubSample.h
+++ b/DataModel/SubSample.h
@@ -11,20 +11,31 @@ class SubSample{
   SubSample();
   SubSample(std::vector<int> PMTid,std::vector<float> time)
     {
+      assert(m_PMTid.size() == m_time.size());
       m_PMTid=PMTid;
       m_time=time;
+      for(unsigned int i = 0; i < m_time.size(); i++) {
+	m_time_int[i] = m_time[i];
+      }
     }
 
   SubSample(std::vector<int> PMTid, std::vector<float> time, std::vector<float> charge)
     {
+      assert(m_PMTid.size() == m_time.size() && m_PMTid.size() == m_charge.size());
       m_PMTid  = PMTid;
       m_time   = time;
       m_charge = charge;
+      for(unsigned int i = 0; i < m_time.size(); i++) {
+	m_time_int[i] = m_time[i];
+	m_charge_int[i] = m_charge[i];
+      }
     }
 
   std::vector<int> m_PMTid;
   std::vector<float> m_time;
   std::vector<float> m_charge;
+  std::vector<int> m_time_int;
+  std::vector<int> m_charge_int;
 
 };
 

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -23,6 +23,8 @@ bool DataOut::Initialise(std::string configfile, DataModel &data){
   //other options
   fSaveMultiDigiPerTrigger = true;
   m_variables.Get("save_multiple_digits_per_trigger", fSaveMultiDigiPerTrigger);
+  fTriggerOffset = 0;
+  m_variables.Get("trigger_offset", fTriggerOffset);
 
   //setup the out event tree
   // Nevents unique event objects
@@ -140,7 +142,7 @@ void DataOut::CreateSubEvents(WCSimRootEvent * WCSimEvent)
     if(i)
       WCSimEvent->AddSubEvent();
     WCSimRootTrigger * trig = WCSimEvent->GetTrigger(i);
-    int offset = fTriggers->m_type.at(i) == kTriggerNoTrig ? 0 : 950;
+    double offset = fTriggerOffset;
     trig->SetHeader(fEvtNum, 0, fTriggers->m_triggertime.at(i) - offset, i+1);
     trig->SetTriggerInfo(fTriggers->m_type.at(i), fTriggers->m_info.at(i));
     //trig->SetMode(jhfNtuple.mode);
@@ -187,8 +189,7 @@ void DataOut::RemoveDigits(WCSimRootEvent * WCSimEvent, std::map<int, std::map<i
     int pmt = d->GetTubeId();
     if(window >= 0) {
       //need to apply an offset to the digit time using the trigger time
-      if(fTriggers->m_type.at(window) != kTriggerNoTrig)
-	d->SetT(time + 950. - fTriggers->m_triggertime.at(window));
+      d->SetT(time + fTriggerOffset - fTriggers->m_triggertime.at(window));
     }
     if(window > 0 &&
        (!fSaveMultiDigiPerTrigger && !NDigitPerPMTPerTriggerMap[pmt][window])) {

--- a/UserTools/DataOut/DataOut.h
+++ b/UserTools/DataOut/DataOut.h
@@ -42,6 +42,7 @@ class DataOut: public Tool {
   TString * fWCSimFilename;
 
   TriggerInfo * fTriggers;
+  double fTriggerOffset;
 
   int fEvtNum;
 

--- a/UserTools/DataOut/DataOut.h
+++ b/UserTools/DataOut/DataOut.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <iostream>
+#include <map>
 
 #include "WCSimRootEvent.hh"
 #include "WCSimRootGeom.hh"
@@ -27,7 +28,8 @@ class DataOut: public Tool {
  private:
   void CreateSubEvents(WCSimRootEvent * WCSimEvent);
   void FinaliseSubEvents(WCSimRootEvent * WCSimEvent);
-  void RemoveDigits(WCSimRootEvent * WCSimEvent);
+  void RemoveDigits(WCSimRootEvent * WCSimEvent,
+		    std::map<int, std::map<int, bool> > & NDigitPerPMTPerTriggerMap);
   int  TimeInTriggerWindow(double time);
 
   std::string fOutFilename;
@@ -39,10 +41,13 @@ class DataOut: public Tool {
   WCSimRootEvent * fWCSimEventOD;
   TString * fWCSimFilename;
 
-  std::vector<std::pair<double, double> > fTriggerIntervals;
   TriggerInfo * fTriggers;
 
   int fEvtNum;
+
+  bool fSaveMultiDigiPerTrigger;
+  std::map<int, std::map<int, bool> > fIDNDigitPerPMTPerTriggerMap;
+  std::map<int, std::map<int, bool> > fODNDigitPerPMTPerTriggerMap;
 
   int verbose;
 

--- a/UserTools/DataOut/README.md
+++ b/UserTools/DataOut/README.md
@@ -25,7 +25,11 @@ DataOut
 ```
 outfilename /path/to/file
 verbose LEVEL
+save_multiple_digits_per_trigger [0,1]
+trigger_offset OFFSET
 ```
 
 * `outfilename` File path to output file
 * `verbose` Verbosity level. Runs from 0 (low verbosity) to 9 (high verbosity)
+* `save_multiple_digits_per_trigger` is a boolean flag. If false, will only allow one digit per PMT per trigger window to be written. If true, writes out as many as exist
+* `trigger_offset` Offset applied to trigger time to account for `WCSimWCTriggerBase::offset` constant (set to 950 ns by default). This is related to SKI delay in the electronics/DAQ

--- a/UserTools/Factory/Factory.cpp
+++ b/UserTools/Factory/Factory.cpp
@@ -12,6 +12,7 @@ if (tool=="nhits") ret=new nhits;
 if (tool=="test_vertices") ret=new test_vertices;
 if (tool=="WCSimReader") ret=new WCSimReader;
 if (tool=="DataOut") ret=new DataOut;
+  if (tool=="pass_all") ret=new pass_all;
 return ret;
 }
 

--- a/UserTools/Unity.cpp
+++ b/UserTools/Unity.cpp
@@ -5,3 +5,4 @@
 #include "test_vertices/test_vertices.cpp"
 #include "WCSimReader/WCSimReader.cpp"
 #include "DataOut/DataOut.cpp"
+#include "pass_all/pass_all.cpp"

--- a/UserTools/nhits/README.md
+++ b/UserTools/nhits/README.md
@@ -1,19 +1,46 @@
 # nhits
 
-nhits
+nhits is a trigger that sums the number of digits in a sliding time window. If the sum is above a threshold, a trigger is issued.
+CPU and CUDA-GPU versions are available
 
 ## Data
 
-Describe any data formats nhits creates, destroys, changes, analyzes, or its usage.
-
-
+* [GPU] Initialises GPU
+* Adjusts threshold for noise (if set)
+* For each Execute() call
+  * Gets the relevant list of hits (i.e. ID or OD)
+  * Runs the CPU or GPU algorithm
+  * For each trigger found, adds to `IDTriggers` or `ODTriggers` with the properties
+    * Type `kTriggerNDigits`
+    * Trigger readout window [trigger time - `pretrigger_save_window`, trigger time + `posttrigger_save_window`] ns
+    * Trigger time: the time of the first hit above threshold in the sliding window.
+      * If the window has 40 hits
+      * And the threshold is 25
+      * The trigger time will be the time of the 26th digit
+      	* Note sorting by time is done to ensure this
+    * Info: one entry with number of ID digits in the sliding window that issued the trigger
+* [GPU] Finalises GPU
 
 
 ## Configuration
 
-Describe any configuration variables for nhits.
+```
+trigger_search_window WINDOW
+trigger_search_window_step STEP
+trigger_threshold THRESHOLD
+trigger_threshold_adjust_for_noise [0,1]
+pretrigger_save_window PRETRIGGER
+posttrigger_save_window POSTTRIGGER
+trigger_od [0,1]
+verbose LEVEL
+```
 
-```
-param1 value1
-param2 value2
-```
+* `trigger_search_window` The width of the window that sums nhits
+* `trigger_search_window_step` The slide step of the window that sums hits
+* `trigger_threshold` The threshold, above which the trigger fires
+  * Not equal to does not fire the trigger
+* `trigger_threshold_adjust_for_noise` Boolean. If true, the trigger threshold will be increased by the average dark noise occupancy in the sliding window. If false, the trigger threshold will not be modified
+* `pretrigger_save_window` Once a trigger is issued, how much data should be read out before it
+* `posttrigger_save_window` Once a trigger is issued, how much data should be read out after it
+* `trigger_od` Boolean. If true, the trigger runs on OD hits. If false, the trigger runs on ID hits.
+* `verbose` Verbosity level. Runs from 0 (low verbosity) to 9 (high verbosity)

--- a/UserTools/nhits/nhits.cpp
+++ b/UserTools/nhits/nhits.cpp
@@ -123,7 +123,8 @@ void nhits::AlgNDigits(const SubSample * sample)
   }//loop over Digits
   int window_start_time = firsthit;
   window_start_time -= window_start_time % 5;
-  int window_end_time   = lasthit - (fTriggerSearchWindow - fTriggerSearchWindowStep);
+  int window_end_time   = lasthit - fTriggerSearchWindow + fTriggerSearchWindowStep;
+  window_end_time -= window_end_time % 5;
   ss << "DEBUG: Found first/last hits. Looping from " << window_start_time
      << " to " << window_end_time 
      << " in steps of " << fTriggerSearchWindowStep;

--- a/UserTools/pass_all/README.md
+++ b/UserTools/pass_all/README.md
@@ -1,0 +1,19 @@
+# pass_all
+
+pass_all
+
+## Data
+
+Describe any data formats pass_all creates, destroys, changes, analyzes, or its usage.
+
+
+
+
+## Configuration
+
+Describe any configuration variables for pass_all.
+
+```
+param1 value1
+param2 value2
+```

--- a/UserTools/pass_all/README.md
+++ b/UserTools/pass_all/README.md
@@ -1,19 +1,15 @@
 # pass_all
 
-pass_all
+pass_all is a dummy trigger that creates a single very long readout trigger window that (should) pass everything
 
 ## Data
 
-Describe any data formats pass_all creates, destroys, changes, analyzes, or its usage.
-
-
-
+Adds a trigger to `IDTriggers` that has the properties
+* Type `kTriggerNoTrig`
+* Trigger readout window [-10,+10] ms
+* Trigger time 0
+* Info: one entry with number of ID digits
 
 ## Configuration
 
-Describe any configuration variables for pass_all.
-
-```
-param1 value1
-param2 value2
-```
+No configuration options exist

--- a/UserTools/pass_all/pass_all.cpp
+++ b/UserTools/pass_all/pass_all.cpp
@@ -1,0 +1,32 @@
+#include "pass_all.h"
+
+pass_all::pass_all():Tool(){}
+
+
+bool pass_all::Initialise(std::string configfile, DataModel &data){
+
+  if(configfile!="")  m_variables.Initialise(configfile);
+  //m_variables.Print();
+
+  m_data= &data;
+
+  return true;
+}
+
+
+bool pass_all::Execute(){
+  int n_digits = m_data->IDSamples.at(0).m_time.size();
+  m_data->IDTriggers.AddTrigger(kTriggerNoTrig,
+				-1E6,
+				+1E6,
+				0,
+				std::vector<float>(1, n_digits));
+
+  return true;
+}
+
+
+bool pass_all::Finalise(){
+
+  return true;
+}

--- a/UserTools/pass_all/pass_all.cpp
+++ b/UserTools/pass_all/pass_all.cpp
@@ -17,8 +17,8 @@ bool pass_all::Initialise(std::string configfile, DataModel &data){
 bool pass_all::Execute(){
   int n_digits = m_data->IDSamples.at(0).m_time.size();
   m_data->IDTriggers.AddTrigger(kTriggerNoTrig,
-				-1E6,
-				+1E6,
+				-10E6, //-10ms
+				+10E6, //+10ms
 				0,
 				std::vector<float>(1, n_digits));
 

--- a/UserTools/pass_all/pass_all.h
+++ b/UserTools/pass_all/pass_all.h
@@ -1,0 +1,29 @@
+#ifndef pass_all_H
+#define pass_all_H
+
+#include <string>
+#include <iostream>
+
+#include "Tool.h"
+
+class pass_all: public Tool {
+
+
+ public:
+
+  pass_all();
+  bool Initialise(std::string configfile,DataModel &data);
+  bool Execute();
+  bool Finalise();
+
+
+ private:
+
+
+
+
+
+};
+
+
+#endif

--- a/configfiles/WCSimReaderTest/DataOutToolConfig
+++ b/configfiles/WCSimReaderTest/DataOutToolConfig
@@ -1,3 +1,4 @@
 verbose 3
 outfilename triggered.root
 save_multiple_digits_per_trigger 1
+trigger_offset 950

--- a/configfiles/WCSimReaderTest/DataOutToolConfig
+++ b/configfiles/WCSimReaderTest/DataOutToolConfig
@@ -1,2 +1,3 @@
 verbose 3
 outfilename triggered.root
+save_multiple_digits_per_trigger 1

--- a/configfiles/WCSimReaderTest/ToolsConfig
+++ b/configfiles/WCSimReaderTest/ToolsConfig
@@ -1,3 +1,4 @@
 wcsim1 WCSimReader configfiles/WCSimReaderTest/WCSimReaderToolConfig
 nhits1 nhits configfiles/WCSimReaderTest/nhitsToolConfig
+#pass_all1 pass_all configfiles/WCSimReaderTest/pass_allToolConfig
 out1 DataOut configfiles/WCSimReaderTest/DataOutToolConfig


### PR DESCRIPTION
Validation almost done! All comparisons were done using a NoTrigger WCSim file and run through complete_comparison.C
* pass_all exactly reproduces WCSim NoTrigger 
* nhits CPU exactly reproduces WCSim NDigits trigger (run with `save_multiple_digits_per_trigger` and `/DAQ/MultiDigitsPerTrigger` set to both true and false) when running with electron particle gun
  * This was one of the problems yesterday (I forgot what the WCSim default was)
  * Not that there is a ~1E-4 shift in digit times. This is due to the 950 ns offset `WCSimWCTriggerBase::offset` that needs to be subtracted from digit times in DataOut. If this offset is set to 0, everything is exact to better than 1E-6 (the default precision of complete_comparison.C)
    * I added a parameter `DataOut` called `trigger_offset` to change this offset
* Note for now that nhits CPU has some discrepancies relative to WCSim NDigits trigger (run with `save_multiple_digits_per_trigger` and `/DAQ/MultiDigitsPerTrigger` set to both true and false) when running with muon particle gun
  * Some muon events have subevents due to decay electron
  * This requires some more changes, related to having to move tracks from trigger 0 to trigger 1
  * I'll get to this...

Anyway, what this PR does:
* Adds `save_multiple_digits_per_trigger` and `trigger_offset` options to `DataOut`
* Sanitise `window_end_time` in `nhits::AlgNDigits()`
* Adds a .gitignore
* Adds a pass_all trigger (useful for debugging against WCSim's NoTrigger)

Note that there are changes in my WCSim trigger branch. The major one being:
  * Making sure NoTrigger saves everything
    * Negative digits being dropped was the other problem from yesterday