### PR TITLE
Add ability to move true tracks between WCSimRootTriggers

### DIFF
--- a/DataModel/SubSample.h
+++ b/DataModel/SubSample.h
@@ -11,9 +11,11 @@ class SubSample{
   SubSample();
   SubSample(std::vector<int> PMTid,std::vector<float> time)
     {
-      assert(m_PMTid.size() == m_time.size());
+      assert(PMTid.size() == time.size());
       m_PMTid=PMTid;
       m_time=time;
+      //fill the int versions
+      m_time_int.resize(m_time.size());
       for(unsigned int i = 0; i < m_time.size(); i++) {
 	m_time_int[i] = m_time[i];
       }
@@ -21,10 +23,13 @@ class SubSample{
 
   SubSample(std::vector<int> PMTid, std::vector<float> time, std::vector<float> charge)
     {
-      assert(m_PMTid.size() == m_time.size() && m_PMTid.size() == m_charge.size());
+      assert(PMTid.size() == time.size() && PMTid.size() == charge.size());
       m_PMTid  = PMTid;
       m_time   = time;
       m_charge = charge;
+      //fill the int versions
+      m_time_int.resize(m_time.size());
+      m_charge_int.resize(m_time.size());
       for(unsigned int i = 0; i < m_time.size(); i++) {
 	m_time_int[i] = m_time[i];
 	m_charge_int[i] = m_charge[i];

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -152,7 +152,7 @@ void DataOut::CreateSubEvents(WCSimRootEvent * WCSimEvent)
     double offset = fTriggerOffset;
     trig->SetHeader(fEvtNum, 0, fTriggers->m_triggertime.at(i) - offset, i+1);
     trig->SetTriggerInfo(fTriggers->m_type.at(i), fTriggers->m_info.at(i));
-    //trig->SetMode(jhfNtuple.mode);
+    trig->SetMode(0);
   }//i
 }
 /////////////////////////////////////////////////////////////////

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -150,7 +150,7 @@ void DataOut::CreateSubEvents(WCSimRootEvent * WCSimEvent)
       WCSimEvent->AddSubEvent();
     WCSimRootTrigger * trig = WCSimEvent->GetTrigger(i);
     double offset = fTriggerOffset;
-    trig->SetHeader(fEvtNum, 0, fTriggers->m_triggertime.at(i) - offset, i+1);
+    trig->SetHeader(fEvtNum, 0, fTriggers->m_triggertime.at(i), i+1);
     trig->SetTriggerInfo(fTriggers->m_type.at(i), fTriggers->m_info.at(i));
     trig->SetMode(0);
   }//i
@@ -162,7 +162,7 @@ void DataOut::FinaliseSubEvents(WCSimRootEvent * WCSimEvent)
   for(int i = 0; i < n; i++) {
     WCSimRootTrigger * trig = WCSimEvent->GetTrigger(i);
     TClonesArray * digits = trig->GetCherenkovDigiHits();
-    float sumq = 0;
+    double sumq = 0;
     int ntubeshit = 0;
     for(int j = 0; j < trig->GetNcherenkovdigihits_slots(); j++) {
       WCSimRootCherenkovDigiHit * digi = (WCSimRootCherenkovDigiHit *)digits->At(j);
@@ -196,7 +196,10 @@ void DataOut::RemoveDigits(WCSimRootEvent * WCSimEvent, std::map<int, std::map<i
     int pmt = d->GetTubeId();
     if(window >= 0) {
       //need to apply an offset to the digit time using the trigger time
-      d->SetT(time + fTriggerOffset - fTriggers->m_triggertime.at(window));
+      double t = - fTriggers->m_triggertime.at(window)
+	+ fTriggerOffset
+	+ time;
+      d->SetT(t);
     }
     if(window > 0 &&
        (fSaveMultiDigiPerTrigger ||
@@ -226,7 +229,7 @@ void DataOut::RemoveDigits(WCSimRootEvent * WCSimEvent, std::map<int, std::map<i
 /////////////////////////////////////////////////////////////////
 void DataOut::MoveTracks(WCSimRootEvent * WCSimEvent)
 {
-  if(!fTriggers->m_N)
+  if(fTriggers->m_N < 2)
     return;
   WCSimRootTrigger * trig0 = WCSimEvent->GetTrigger(0);
   TClonesArray * tracks = trig0->GetTracks();
@@ -248,7 +251,7 @@ void DataOut::MoveTracks(WCSimRootEvent * WCSimEvent)
     }
   }//i
   ss << "INFO: MoveTracks() has reduced number of tracks in the 0th trigger from "
-     << ntracks << " to " << trig0->GetNcherenkovdigihits();
+     << ntracks << " to " << trig0->GetNtrack();
   StreamToLog(INFO);
 }
 /////////////////////////////////////////////////////////////////

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -192,9 +192,12 @@ void DataOut::RemoveDigits(WCSimRootEvent * WCSimEvent, std::map<int, std::map<i
       d->SetT(time + fTriggerOffset - fTriggers->m_triggertime.at(window));
     }
     if(window > 0 &&
-       (!fSaveMultiDigiPerTrigger && !NDigitPerPMTPerTriggerMap[pmt][window])) {
+       (fSaveMultiDigiPerTrigger ||
+	(!fSaveMultiDigiPerTrigger && !NDigitPerPMTPerTriggerMap[pmt][window]))) {
       //need to add digit to a new trigger window
       //but not if we've already saved the 1 digit from this pmt in this window we're allowed
+      ss << "Adding digit to trigger " << window;
+      StreamToLog(DEBUG3);
       WCSimEvent->GetTrigger(window)->AddCherenkovDigiHit(d);
     }
     if(window ||

--- a/UserTools/DataOut/DataOut.h
+++ b/UserTools/DataOut/DataOut.h
@@ -30,7 +30,9 @@ class DataOut: public Tool {
   void FinaliseSubEvents(WCSimRootEvent * WCSimEvent);
   void RemoveDigits(WCSimRootEvent * WCSimEvent,
 		    std::map<int, std::map<int, bool> > & NDigitPerPMTPerTriggerMap);
+  void MoveTracks(WCSimRootEvent * WCSimEvent);
   int  TimeInTriggerWindow(double time);
+  unsigned int TimeInTriggerWindowNoDelete(double time);
 
   std::string fOutFilename;
   TFile fOutFile;

--- a/UserTools/DataOut/README.md
+++ b/UserTools/DataOut/README.md
@@ -13,12 +13,26 @@ DataOut
     * `wcsimrootoptions` of type `WCSimRootOptions` is a direct clone of the input tree
     * `wcsimfilename` of type `TObjString` is the WCSim file this options class came from
   3. `wcsimT` has N events entries
-    * `wcsimrootevent` of type `WCSimRootEvent` stores the ID events. This is identical to the WCSim event tree, with digits outside the trigger window removed*
-    * `wcsimrootevent_OD` of type `WCSimRootEvent` stores the OD events. This is identical to the WCSim event tree, with digits outside the trigger window removed*
+    * `wcsimrootevent` of type `WCSimRootEvent` stores the ID events. This is identical to the WCSim event tree, with digits outside the trigger window removed
+    * `wcsimrootevent_OD` of type `WCSimRootEvent` stores the OD events. This is identical to the WCSim event tree, with digits outside the trigger window removed
     * `wcsimfilename` of type `TObjArray` of `TObjString` stores the WCSim filename(s) of the current event
     * `wcsimeventnums` of type `vector<int>` stors the WCSim event number(s) of the current event
-* *Any digit that is not in the trigger window is removed from the output `TClonesArray`
-  * Currently a fixed cutoff of 1000 ns is used
+* Any digit that is not in a trigger window is removed from the output `TClonesArray`
+  * This is done using a combination of `IDTriggers` and `ODTriggers` that triggers have filled
+    * e.g. if an OD digit is doesn't have any OD triggers, but is within an ID trigger window, the OD digit will be saved
+    * This is different to WCSim which handles ID/OD triggers separately
+  * The logic of which trigger to add a digit too is:
+    * Time order the triggers
+    * It is then the first trigger the digit is in
+  * If there are no trigger windows, every digit will be removed
+  * Digits that are triggered, but not in the 0th trigger window, are added to the relevant window before removal from the 0th trigger
+* Truth tracks are also moved into their corresponding trigger window
+  * However the logic is slightly different (since they are never dropped)
+    * If they are in the 0th trigger readout window, store in 0th trigger
+    * If they are after the 0th readout window and before the end of the 1st trigger window, store in the 1st trigger
+    * etc
+    * But note that WCSimRootTrigger object aren't created just for tracks, therefore if the track time is beyond the last trigger window, it is stored in the last trigger
+  * Note that this is not exactly equivalent to WCSim. WCSim uses a fixed "`trigger_time` + 950 ns" for this check, rather than "`trigger_time` + `postrigger_save_window`"
 
 ## Configuration
 


### PR DESCRIPTION
Validation with muons complete. This time, I used a combination of `complete_comparison.C` and `verification_HitsChargeTime.C`
* Exact equality in tracks array
* Sometimes a difference in the order of digits in triggers that aren't the 0th
* Exactly equality in the `verification_HitsChargeTime.C` plots
* Note there is still the small precision difference in digit times. Also small precision difference in SumQ (sum of digit charge) when the digits are added in a different order

So the changes:
* Bug fix in the `SubSample` constructors so they don't seg fault
* Fix logic of adding a digit in the case where `save_multiple_digits_per_trigger` is true
* Implement moving of tracks between WCSimRootTrigger's
* DataOut README expansion

This requires an update of the WCSim in the docker. Hopefully it picks it up ok!

This solves #11 