### PR TITLE
Added nclusters part of supernova warning to dimfit tool

### DIFF
--- a/DataModel/DataModel.h
+++ b/DataModel/DataModel.h
@@ -73,6 +73,7 @@ class DataModel {
   WCSimRootEvent * IDWCSimEvent_Triggered;
   WCSimRootEvent * ODWCSimEvent_Triggered;
 
+  std::vector<SNWarningParams> SupernovaWarningParameters;
 
   bool HasOD;
   bool IsMC;

--- a/DataModel/README.md
+++ b/DataModel/README.md
@@ -16,6 +16,7 @@ Table of Contents
          * [Reconstruction information](#reconstruction-information)
             * [Helper functions](#helper-functions)
          * [WCSim pass-through information](#wcsim-pass-through-information)
+         * [Supernova Trigger](#supernova-trigger)
          * [Misc](#misc)
       * [Related classes](#related-classes)
          * [SubSample](#subsample)
@@ -89,6 +90,12 @@ The variables in this DataModel used by TriggerApplication tools are
 |  `TObjArray *`            | CurrentWCSimFiles     | The original WCSim files' filename(s) for the current event     | DataOut | WCSimReader | WCSimReader |
 |  `WCSimRootEvent *`       | IDWCSimEvent_Raw      | The original, unmodified `WCSimRootEvent` for the ID | DataOut | WCSimReader | - |
 |  `WCSimRootEvent *`       | ODWCSimEvent_Raw      | The original, unmodified `WCSimRootEvent` for the OD | DataOut | WCSimReader | - |
+
+### Supernova Trigger
+
+| Type                      | Name                | Purpose | Read by | Modified by | Reset by |
+| ------------------------- | ------------------- | ------- | ------- | ----------- | -------- |
+| `std::vector<SNWarningParams>` | SupernovaWarningParameters | Store the dimensionality, number of reconstructed vertices and the highest nclusters warning threshold passed | - | dimfit | - |
 
 ### Misc
 
@@ -221,6 +228,9 @@ void Reset()
 #### Related things
 
 * `enum Reconstructer_t` - an enumeration of reconstruction tools. E.g. `kReconBONSAI`
+* `enum NClustersWarning_t` - an enumeration of the nclusters warning thresholds used in the supernova trigger
+* `enum SNWarning_t` - an enumeration of supernova warning levels that are assigned based on the values of nclusters and dimensionality
+* `struct SNWarningParams` holds nclusters, dim and highest nclusters threshold passed
 * `struct Pos3D` holds x, y, z positions
 * `struct DirectionEuler` holds theta, phi, alpha directions
 * `struct CherenkovCone` holds cos_angle, ellipticity of the Chrenkov cone

--- a/DataModel/ReconInfo.cpp
+++ b/DataModel/ReconInfo.cpp
@@ -108,6 +108,70 @@ Reconstructer_t ReconInfo::ReconstructerFromString(std::string s)
   return kReconUndefined;
 }
 
+std::string ReconInfo::EnumAsString(NClustersWarning_t w)
+{
+  switch(w) {
+  case (kNClustersStandard):
+    return "NoNClustersWarning";
+    break;
+  case (kNClustersSilent):
+    return "NClustersSilentWarning";
+    break;
+  case (kNClustersNormal):
+    return "NClustersNormalWarning";
+    break;
+  case (kNClustersGolden):
+    return "NClustersGoldenWarning";
+    break;
+  default:
+    return "";
+  }
+  return "";
+}
+
+NClustersWarning_t ReconInfo::NClustersWarningFromString(std::string s)
+{
+  for(int i = int(kNClustersUndefined)+1; i <= kNClustersGolden; i++) {
+    if(s.compare(ReconInfo::EnumAsString((NClustersWarning_t)i)) == 0) {
+      return (NClustersWarning_t)i;
+    }
+  }
+  std::cerr << "ReconInfo::NClustersWarningFromString() Unknown string value " << s << std::endl;
+  return kNClustersUndefined;
+}
+
+std::string ReconInfo::EnumAsString(SNWarning_t w)
+{
+  switch(w) {
+  case (kSNWarningStandard):
+    return "NoSupernovaWarning";
+    break;
+  case (kSNWarningSilent):
+    return "SupernovaSilentWarning";
+    break;
+  case (kSNWarningNormal):
+    return "SupernovaNormalWarning";
+    break;
+  case (kSNWarningGolden):
+    return "SupernovaGoldenWarning";
+    break;
+  default:
+    return "";
+  }
+  return "";
+}
+
+SNWarning_t ReconInfo::SNWarningFromString(std::string s)
+{
+  for(int i = int(kSNWarningUndefined)+1; i <= kSNWarningGolden; i++) {
+    if(s.compare(ReconInfo::EnumAsString((SNWarning_t)i)) == 0) {
+      return (SNWarning_t)i;
+    }
+  }
+  std::cerr << "ReconInfo::SNWarningFromString() Unknown string value " << s << std::endl;
+  return kSNWarningUndefined;
+}
+
 bool ReconInfo::ShouldProvideDirection(Reconstructer_t r)
 {
   switch(r) {

--- a/DataModel/ReconInfo.h
+++ b/DataModel/ReconInfo.h
@@ -14,6 +14,22 @@ typedef enum EReconstructers {
   kReconRandom //ensure this stays at the end, for looping purposes
 } Reconstructer_t;
 
+typedef enum NClustersWarnings {
+  kNClustersUndefined = -1,
+  kNClustersStandard,
+  kNClustersSilent,
+  kNClustersNormal,
+  kNClustersGolden //ensure this stays at the end, for looping purposes
+} NClustersWarning_t;
+
+typedef enum SNWarnings {
+  kSNWarningUndefined = -1,
+  kSNWarningStandard,
+  kSNWarningSilent,
+  kSNWarningNormal,
+  kSNWarningGolden //ensure this stays at the end, for looping purposes
+} SNWarning_t;
+
 struct Pos3D
 {
   double x, y, z;
@@ -28,6 +44,13 @@ struct DirectionEuler
 struct CherenkovCone
 {
   double cos_angle, ellipticity;
+};
+
+struct SNWarningParams
+{
+  int m_dim, m_nclusters;
+  NClustersWarning_t m_nclusters_warning;
+  SNWarningParams(int nclusters,int dim, NClustersWarning_t nclusters_warning){m_nclusters = nclusters; m_dim = dim; m_nclusters_warning = nclusters_warning;};
 };
 
 class ReconInfo
@@ -45,6 +68,14 @@ class ReconInfo
   static std::string EnumAsString(Reconstructer_t r);
   
   static Reconstructer_t ReconstructerFromString(std::string s);
+
+  static std::string EnumAsString(NClustersWarning_t w);
+
+  static NClustersWarning_t NClustersWarningFromString(std::string s);
+
+  static std::string EnumAsString(SNWarning_t w);
+
+  static SNWarning_t SNWarningFromString(std::string s);
 
   static bool ShouldProvideDirection(Reconstructer_t r);
 

--- a/UserTools/README.md
+++ b/UserTools/README.md
@@ -78,6 +78,8 @@ Table of Contents
 * dimfit
   * Find the number of dimensions that a positional vertex distribution corresponds to
   * Algorithm inherited from SK
+  * Compare nclusters to thresholds for golden, normal and silent warnings
+  * Passes dimensionality, nclusters, and highest nclusters_warning level passed to data model
 
 ## Miscellaneous
 

--- a/UserTools/dimfit/README.md
+++ b/UserTools/dimfit/README.md
@@ -19,6 +19,8 @@ Backgrounds should appear non-volume-like. e.g.
   * For reconstructed events that pass a filter (see `ReconFilter`), or all events, fill a vector of positions
   * If there are enough events that pass the criteria, run dimfit
   * Printout the result of dimfit
+  * Compare the number of reconstructed vertices to the thresholds for golden, normal and silent warnings
+  * Pass dimensionality, nclusters and highest nclusters_warning passed to data model
 
 
 ## Configuration
@@ -47,6 +49,16 @@ MAXMEANPOS NUM
 * `LOWDBIAS` Bias chisq towards/away from(???) volume-like
 * `GOODPOINT` If the chisq is less than this, always return point-like
 * `MAXMEANPOS` If the average vertex position is outside a sphere of radius `MAXMEANPOS`, don't return volume-like
+
+### nclusters running parameters
+```
+nclusters_silent_warning NUM
+nclusters_normal_warning NUM
+nclusters_golden_warning NUM
+```
+* `nclusters_silent_warning` The number of vertices needed to trigger a silent warning
+* `nclusters_normal_warning` The number of vertices needed to trigger a normal warning
+* `nclusters_golden_warning` The number of vertices needed to trigger a golden warning
 
 ### Misc
 ```

--- a/UserTools/dimfit/dimfit.cpp
+++ b/UserTools/dimfit/dimfit.cpp
@@ -59,6 +59,20 @@ bool dimfit::Initialise(std::string configfile, DataModel &data){
     Log("WARN: No MAXMEANPOS parameter found. Using a value of 250000", WARN, verbose);
   }
 
+  //nclusters parameters
+  if(!m_variables.Get("nclusters_silent_warning", nclusters_silent_warning)) {
+    nclusters_silent_warning = 200;
+    Log("WARN: No nclusters_silent_warning parameter found. Using a value of 200", WARN, verbose);
+  }
+  if(!m_variables.Get("nclusters_normal_warning", nclusters_normal_warning)) {
+    nclusters_normal_warning = 435;
+    Log("WARN: No nclusters_normal_warning parameter found. Using a value of 435", WARN, verbose);
+  }
+  if(!m_variables.Get("nclusters_golden_warning", nclusters_golden_warning)) {
+    nclusters_golden_warning = 630;
+    Log("WARN: No nclusters_golden_warning parameter found. Using a value of 630", WARN, verbose);
+  }
+
   //allocate memory for a relatively large number of events
   const int n_event_max = 10000;
   fEventPos = new std::vector<double>(n_event_max * 3);
@@ -84,7 +98,7 @@ bool dimfit::Execute(){
   while(tloopend <= tend) {
     fEventPos->clear();
 
-    unsigned int nvertices = 0;
+    unsigned int nclusters = 0;
     for(int irecon = 0; irecon < N; irecon++) {
       //skip events reconstructed outside the time window
       double t = fInFilter->GetTime(irecon);
@@ -98,18 +112,18 @@ bool dimfit::Execute(){
       fEventPos->push_back(pos.x);
       fEventPos->push_back(pos.y);
       fEventPos->push_back(pos.z);
-      nvertices++;
+      nclusters++;
 
       ss << "DEBUG: Adding vertex " << pos.x << ", " << pos.y << "\t" << pos.z << " to run through dimfit";
       StreamToLog(DEBUG3);
     }//irecon
 
     //only call dimfit if there are over (or equal to) the minimum number of vertices
-    if(nvertices >= min_events) {
-      ss << "DEBUG: Running " << nvertices << " event positions through dimfit";
+    if(nclusters >= min_events) {
+      ss << "DEBUG: Running " << nclusters << " event positions through dimfit";
       StreamToLog(DEBUG1);
 
-      dimfit_(nvertices, fEventPos->data(), fCentr, fRot, fRMean, fDim, fExitPoint, verbose);
+      dimfit_(nclusters, fEventPos->data(), fCentr, fRot, fRMean, fDim, fExitPoint, verbose);
 
       ss << "INFO: Dimfit returns " << fDim << " Exited at " << fExitPoint;
       StreamToLog(INFO);
@@ -118,6 +132,19 @@ bool dimfit::Execute(){
     //increment the sliding time window
     tloop += time_window_step_ns;
     tloopend = tloop + time_window_ns;
+
+    //compare nclusters to nclusters warning thresholds
+    NClustersWarning_t nclusters_warning = kNClustersUndefined;
+    if     (nclusters > nclusters_golden_warning) nclusters_warning = kNClustersGolden;
+    else if(nclusters > nclusters_normal_warning) nclusters_warning = kNClustersNormal;
+    else if(nclusters > nclusters_silent_warning) nclusters_warning = kNClustersSilent;
+    else if(nclusters)                            nclusters_warning = kNClustersStandard;
+
+    ss << "INFO: nclusters_warning = " << ReconInfo::EnumAsString(nclusters_warning) << ", nclusters = " << nclusters << " in " << time_window_s << "seconds";
+    StreamToLog(INFO);
+    
+    SNWarningParams supernova_warning_parameters(nclusters,fDim,nclusters_warning);
+    m_data->SupernovaWarningParameters.push_back(supernova_warning_parameters);
 
   }//while(tloop < tend)
 

--- a/UserTools/dimfit/dimfit.cpp
+++ b/UserTools/dimfit/dimfit.cpp
@@ -129,10 +129,6 @@ bool dimfit::Execute(){
       StreamToLog(INFO);
     }
 
-    //increment the sliding time window
-    tloop += time_window_step_ns;
-    tloopend = tloop + time_window_ns;
-
     //compare nclusters to nclusters warning thresholds
     NClustersWarning_t nclusters_warning = kNClustersUndefined;
     if     (nclusters > nclusters_golden_warning) nclusters_warning = kNClustersGolden;
@@ -145,6 +141,10 @@ bool dimfit::Execute(){
     
     SNWarningParams supernova_warning_parameters(nclusters,fDim,nclusters_warning);
     m_data->SupernovaWarningParameters.push_back(supernova_warning_parameters);
+
+    //increment the sliding time window
+    tloop += time_window_step_ns;
+    tloopend = tloop + time_window_ns;
 
   }//while(tloop < tend)
 

--- a/UserTools/dimfit/dimfit.h
+++ b/UserTools/dimfit/dimfit.h
@@ -40,6 +40,10 @@ class dimfit: public Tool {
   double GOODPOINT;
   double MAXMEANPOS;
 
+  int nclusters_silent_warning;
+  int nclusters_normal_warning;
+  int nclusters_golden_warning;
+
   int dimfit_(int n,double *points,double *centr,double *rot,double *rmean, int &dim,int &exitpoint, bool verbose);
   double d_pythag(double a,double b);
   int d_iszero(double *matrix,int sta);

--- a/configfiles/SNTriggering/dimfitToolConfig
+++ b/configfiles/SNTriggering/dimfitToolConfig
@@ -6,4 +6,7 @@ R2MIN 300000
 LOWDBIAS 1.15
 GOODPOINT 40000
 MAXMEANPOS 350000
+nclusters_silent_warning 200
+nclusters_normal_warning 435
+nclusters_golden_warning 630
 verbose 3


### PR DESCRIPTION
Updated dimfit tool compares nclusters to warning thresholds now defined in the dimfitToolConfig file.
nclusters, the dimensionality (fDim), and the highest nclusters warning level reached (nclusters_warning) are passed to the data model at the end of each loop over the time window.

Possibilities of what to do now - open for discussion:
- Take the dimensionality and nclusters_warning and add if statements to assign an overall SN warning variable (using the new SNWarning enums) in the dimfit tool
- Do the above in a separate tool
- Could also be done in the SNWarningParams structure
- Your opinion here