### PR TITLE
Rewrite DataOut & fix a big memory leak

### DIFF
--- a/DataModel/DataModel.h
+++ b/DataModel/DataModel.h
@@ -84,10 +84,10 @@ class DataModel {
   TChain * WCSimOptionsTree;
   /// The `WCSimRootEvent` tree from input WCSim file(s)
   TChain * WCSimEventTree;
-  /// The original WCSim files' event number(s) for the current event
-  std::vector<int> CurrentWCSimEventNums;
-  /// The original WCSim files' filename(s) for the current event
-  TObjArray * CurrentWCSimFiles;
+  /// The original WCSim files' event number for the current event
+  int CurrentWCSimEventNum;
+  /// The original WCSim files' filename for the current event
+  TObjString CurrentWCSimFile;
   /// The original, unmodified `WCSimRootEvent` for the ID
   WCSimRootEvent * IDWCSimEvent_Raw;
   /// The original, unmodified `WCSimRootEvent` for the OD

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -270,11 +270,11 @@ void DataOut::FillHits(WCSimRootEvent * wcsim_event, const TimeDelta & time_shif
       // Move all hits by the *negative* shift. If 5 seconds are added to the
       // trigger time, the hit times (relative to the trigger) must be moved 5
       // seconds back, so they remain at the same absolute time.
-      time -= time_shift / TimeDelta::ns; //Is the time shift in the right place?
+      time -= time_shift;
 
       //hit is in this window. Let's save it
       wcsim_event->GetTrigger(trigger_window_to_check)->AddCherenkovDigiHit(is->m_charge[ihit],
-									    time / TimeDelta::ns, //do i need to do any division here?
+									    time / TimeDelta::ns,
 									    is->m_PMTid[ihit],
 									    photon_id_temp);
       m_ss << "Saved hit " << counter++;

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -68,9 +68,9 @@ bool DataOut::Initialise(std::string configfile, DataModel &data){
   //There are 1 unique geom objects, so this is a simple clone of 1 entry
   if(m_data->IsMC) {
     Log("DEBUG:   Geometry...", DEBUG2, m_verbose);
-    m_tree_geom = m_data->WCSimGeomTree->CloneTree(1);
-    m_tree_geom->Write();
-    delete m_tree_geom;
+    TTree * geom_tree = m_data->WCSimGeomTree->CloneTree(1);
+    geom_tree->Write();
+    delete geom_tree;
   }
   else {
     Log("WARN: TODO Geometry tree filling is not yet implemented for data");
@@ -80,20 +80,20 @@ bool DataOut::Initialise(std::string configfile, DataModel &data){
   // plus a new branch with the wcsim filename 
   if(m_data->IsMC) {
     Log("DEBUG:   Options & file names...", DEBUG2, m_verbose);
-    m_tree_options = m_data->WCSimOptionsTree->CloneTree();
-    m_ss << "DEBUG:     entries: " << m_tree_options->GetEntries();
+    TTree * options_tree = m_data->WCSimOptionsTree->CloneTree();
+    m_ss << "DEBUG:     entries: " << options_tree->GetEntries();
     StreamToLog(DEBUG2);
     TObjString * wcsimfilename = new TObjString();
-    TBranch * branch = m_tree_options->Branch("wcsimfilename", &wcsimfilename);
-    for(int i = 0; i < m_tree_options->GetEntries(); i++) {
+    TBranch * branch = options_tree->Branch("wcsimfilename", &wcsimfilename);
+    for(int i = 0; i < options_tree->GetEntries(); i++) {
       m_data->WCSimOptionsTree->GetEntry(i);
-      m_tree_options->GetEntry(i);
+      options_tree->GetEntry(i);
       wcsimfilename->SetString(m_data->WCSimOptionsTree->GetFile()->GetName());
       branch->Fill();
     }//i
-    m_tree_options->Write();
+    options_tree->Write();
     delete wcsimfilename;
-    delete m_tree_options;
+    delete options_tree;
   }
 
   Log("DEBUG: DataOut::Initialise creating trigger info...", DEBUG2, m_verbose);

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -235,6 +235,7 @@ void DataOut::FillHits(WCSimRootEvent * wcsim_event, const TimeDelta & time_shif
   std::vector<int> photon_id_temp;
   //Loop over all SubSamples
   for(std::vector<SubSample>::iterator is=samples.begin(); is!=samples.end(); ++is){
+    trigger_window_to_check = 0;
     // Make sure hit times are ordered in time
     Log("WARN: TODO Sorting by time, and doing time window checks, will not be required after #49");
     is->SortByTime();

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -247,7 +247,7 @@ void DataOut::FillHits(WCSimRootEvent * wcsim_event, const TimeDelta & time_shif
     const unsigned int nhits = is->m_time.size();
     int counter = 0;
     for(int ihit = 0; ihit < nhits; ihit++) {
-      time = is->m_time[ihit];
+      time = is->AbsoluteDigitTime(ihit);
       m_ss << "Hit " << ihit << " is at time " << time << std::endl
 	   << "Checking hit is in range [" << m_all_triggers->m_starttime.at(trigger_window_to_check)
 	   << ", " << m_all_triggers->m_endtime.at(trigger_window_to_check) << "]";
@@ -283,6 +283,7 @@ void DataOut::FillHits(WCSimRootEvent * wcsim_event, const TimeDelta & time_shif
 }
 /////////////////////////////////////////////////////////////////
 void DataOut::AddTruthInfo(WCSimRootEvent * wcsim_event, WCSimRootEvent * original_wcsim_event, const TimeDelta & time_shift) {
+  
 }
 /////////////////////////////////////////////////////////////////
 void DataOut::FinaliseSubEvents(WCSimRootEvent * wcsim_event) {

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -218,7 +218,7 @@ TimeDelta DataOut::GetOffset(WCSimRootEvent * original_wcsim_event) {
     // The old time (stored in ns)
     TimeDelta old_trigger_time = trig0->GetHeader()->GetDate() * TimeDelta::ns;
     // The difference
-    TimeDelta time_shift = new_trigger_time - old_trigger_time;
+    time_shift += new_trigger_time - old_trigger_time;
     m_ss << "DEBUG: Trigger date shift from " << old_trigger_time << " to " << new_trigger_time << ": " << time_shift;
     StreamToLog(DEBUG2);
   }
@@ -263,8 +263,7 @@ void DataOut::FillHits(WCSimRootEvent * wcsim_event, const TimeDelta & time_shif
 	ihit--;
 	trigger_window_to_check++;
 	Log("Too late", DEBUG3, m_verbose);
-	if(trigger_window_to_check >= m_all_triggers->m_N)
-	  break;
+	if(trigger_window_to_check >= m_all_triggers->m_N) break;
 	continue;
       }
       //hit is in this window. Let's save it

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -383,10 +383,11 @@ void DataOut::AddTruthInfo(WCSimRootEvent * wcsim_event, WCSimRootEvent * origin
 	break;
       }//idigit_old
       if(found) {
-	new_digit->SetPhotonIds(old_digit->GetPhotonIds());
+	//new_digit->SetPhotonIds(old_digit->GetPhotonIds());
       }
     }//idigit
   }//itrigger
+  Log("TODO after WCSim/WCSim#286 is merged, uncomment SetPhotonIds", WARN, m_verbose);
 }
 /////////////////////////////////////////////////////////////////
 void DataOut::FinaliseSubEvents(WCSimRootEvent * wcsim_event) {

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -283,17 +283,19 @@ void DataOut::FinaliseSubEvents(WCSimRootEvent * wcsim_event) {
     WCSimRootTrigger * trig = wcsim_event->GetTrigger(i);
     TClonesArray * hits = trig->GetCherenkovDigiHits();
     double sumq = 0;
-    int ntubeshit = 0;
+    int nhits = 0;
     for(int j = 0; j < trig->GetNcherenkovdigihits_slots(); j++) {
       WCSimRootCherenkovDigiHit * digi = (WCSimRootCherenkovDigiHit *)hits->At(j);
       if(digi) {
 	sumq += digi->GetQ();
-	ntubeshit++;
+	nhits++;
       }
     }//j
     trig->SetSumQ(sumq);
     //this is actually number of hits, not number of unique PMTs with hits
-    trig->SetNumDigitizedTubes(ntubeshit);
+    trig->SetNumDigitizedTubes(nhits);
+    m_ss << "DEBUG: Trigger " << i << " has " << nhits << " hits";
+    StreamToLog(DEBUG1);
   }//i
 }
 /////////////////////////////////////////////////////////////////

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -112,8 +112,6 @@ bool DataOut::Initialise(std::string configfile, DataModel &data){
 bool DataOut::Execute(){
   if(m_stopwatch) m_stopwatch->Start();
 
-  Log("DEBUG: DataOut::Execute Starting", DEBUG1, m_verbose);
-
   //Gather together all the trigger windows
   m_all_triggers->Clear();
   m_all_triggers->AddTriggers(&(m_data->IDTriggers));

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -59,8 +59,8 @@ bool DataOut::Initialise(std::string configfile, DataModel &data){
   else {
     m_data->ODWCSimEvent_Triggered = 0;
   }
-  m_event_tree->Branch("wcsimfilename", &(m_data->CurrentWCSimFiles), bufsize, 0);
-  m_event_tree->Branch("wcsimeventnums", &(m_data->CurrentWCSimEventNums), bufsize, 0);
+  m_event_tree->Branch("wcsimfilename", &(m_data->CurrentWCSimFile));
+  m_event_tree->Branch("wcsimeventnum", &(m_data->CurrentWCSimEventNum));
 
   //fill the output event-independent trees
   Log("DEBUG: DataOut::Initialise filling event-independent trees...", DEBUG2, m_verbose);

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -175,7 +175,7 @@ void DataOut::ExecuteSubDet(WCSimRootEvent * wcsim_event, std::vector<SubSample>
 
   //For every hit, if it's in a trigger window,
   //add it to the appropriate WCSimRootTrigger in the WCSimRootEvent
-  FillHits(wcsim_event, time_shift, samples);
+  FillHits(wcsim_event, samples);
 
   //If this is an MC file, we also need to add
   // - true tracks
@@ -229,7 +229,7 @@ TimeDelta DataOut::GetOffset(WCSimRootEvent * original_wcsim_event) {
   return time_shift;
 }
 /////////////////////////////////////////////////////////////////
-void DataOut::FillHits(WCSimRootEvent * wcsim_event, const TimeDelta & time_shift, std::vector<SubSample> & samples) {
+void DataOut::FillHits(WCSimRootEvent * wcsim_event, std::vector<SubSample> & samples) {
   unsigned int trigger_window_to_check;
   TimeDelta time;
   std::vector<int> photon_id_temp;
@@ -263,9 +263,10 @@ void DataOut::FillHits(WCSimRootEvent * wcsim_event, const TimeDelta & time_shif
 	continue;
       }
 
-      // + time_shift adds the WCSim Date, and adds the user-defined "offset"
-      // - trigger_time because hits are defined relative to their trigger time
-      time += time_shift - m_all_triggers->m_triggertime.at(trigger_window_to_check);
+      // + m_trigger_offset adds the user-defined "offset"
+      // - trigger time ("Date") because hits are defined relative to their trigger time
+      time += m_trigger_offset -
+	(wcsim_event->GetTrigger(trigger_window_to_check)->GetHeader()->GetDate() * TimeDelta::ns);
 
       //hit is in this window. Let's save it
       wcsim_event->GetTrigger(trigger_window_to_check)->AddCherenkovDigiHit(is->m_charge[ihit],

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -31,15 +31,18 @@ bool DataOut::Initialise(std::string configfile, DataModel &data){
     Log("ERROR: outfilename configuration not found. Cancelling initialisation", ERROR, m_verbose);
     return false;
   }
-  m_output_file.Open(m_output_filename.c_str(), "RECREATE");
+  m_output_file = new TFile(m_output_filename.c_str(), "RECREATE");
 
   //other options
   m_save_multiple_hits_per_trigger = true;
   m_variables.Get("save_multiple_digits_per_trigger", m_save_multiple_hits_per_trigger);
-  m_trigger_offset = 0;
-  m_variables.Get("trigger_offset", m_trigger_offset);
+  Log("WARN: TODO save_multiple_digits_per_trigger is not currently implemented", WARN, m_verbose);
+  double trigger_offset_temp = 0;
+  m_variables.Get("trigger_offset", trigger_offset_temp);
+  m_trigger_offset = TimeDelta(trigger_offset_temp);
   m_save_only_failed_digits = false;
   m_variables.Get("save_only_failed_digits", m_save_only_failed_digits);
+  Log("WARN: TODO save_only_failed_digits is not currently implemented", WARN, m_verbose);
 
   //setup the out event tree
   Log("DEBUG: DataOut::Initialise setting up output event tree...", DEBUG2, m_verbose);
@@ -47,9 +50,11 @@ bool DataOut::Initialise(std::string configfile, DataModel &data){
   Int_t bufsize = 64000;
   m_event_tree = new TTree("wcsimT","WCSim Tree");
   m_data->IDWCSimEvent_Triggered = new WCSimRootEvent();
+  m_data->IDWCSimEvent_Triggered->Initialize();
   m_event_tree->Branch("wcsimrootevent", "WCSimRootEvent", &m_data->IDWCSimEvent_Triggered, bufsize,2);
   if(m_data->HasOD) {
     m_data->ODWCSimEvent_Triggered = new WCSimRootEvent();
+    m_data->ODWCSimEvent_Triggered->Initialize();
     m_event_tree->Branch("wcsimrootevent_OD", "WCSimRootEvent", &m_data->ODWCSimEvent_Triggered, bufsize,2);
   }
   else {
@@ -59,12 +64,18 @@ bool DataOut::Initialise(std::string configfile, DataModel &data){
   m_event_tree->Branch("wcsimeventnums", &(m_data->CurrentWCSimEventNums), bufsize, 0);
 
   //fill the output event-independent trees
-  //There are 1 unique geom objects, so this is a simple clone of 1 entry
   Log("DEBUG: DataOut::Initialise filling event-independent trees...", DEBUG2, m_verbose);
-  Log("DEBUG:   Geometry...", DEBUG2, m_verbose);
-  m_tree_geom = m_data->WCSimGeomTree->CloneTree(1);
-  m_tree_geom->Write();
-  delete m_tree_geom;
+
+  //There are 1 unique geom objects, so this is a simple clone of 1 entry
+  if(m_data->IsMC) {
+    Log("DEBUG:   Geometry...", DEBUG2, m_verbose);
+    m_tree_geom = m_data->WCSimGeomTree->CloneTree(1);
+    m_tree_geom->Write();
+    delete m_tree_geom;
+  }
+  else {
+    Log("WARN: TODO Geometry tree filling is not yet implemented for data");
+  }
 
   //There are Nfiles unique options objects, so this is a clone of all entries
   // plus a new branch with the wcsim filename 
@@ -138,32 +149,18 @@ bool DataOut::Execute(){
     StreamToLog(INFO);
   }//i
 
-  //Note: the ranges vector can contain overlapping ranges
+  //Note: the trigger ranges vector can contain overlapping ranges
   //we want to make sure the triggers output aren't overlapping
-  // This is actually handled in DataOut::RemoveDigits()
+  // This is actually handled in DataOut::FillDigits()
   // It puts digits into the output event in the earliest trigger they belong to
 
-  //get the WCSim event
-  (*m_data->IDWCSimEvent_Triggered) = (*(m_data->IDWCSimEvent_Raw));
-  //prepare the subtriggers
-  CreateSubEvents(m_data->IDWCSimEvent_Triggered);
-  //remove the digits that aren't in the trigger window(s)
-  // also move digits from the 0th trigger to the trigger window it's in
-  RemoveDigits(m_data->IDWCSimEvent_Triggered, m_id_nhits_per_pmt_per_trigger);
-  //also redistribute some true tracks
-  MoveTracks(m_data->IDWCSimEvent_Triggered);
-  //set some trigger header infromation that requires all the digits to be 
-  // present to calculate e.g. sumq
-  FinaliseSubEvents(m_data->IDWCSimEvent_Triggered);
-  
+  //Fill the WCSimRootEvent with hit/trigger information, and truth information (if available)
+  ExecuteSubDet(m_data->IDWCSimEvent_Triggered, m_data->IDSamples, m_data->IDWCSimEvent_Raw);
   if(m_data->HasOD) {
-    (*m_data->ODWCSimEvent_Triggered) = (*(m_data->ODWCSimEvent_Raw));
-    CreateSubEvents(m_data->ODWCSimEvent_Triggered);
-    RemoveDigits(m_data->ODWCSimEvent_Triggered, m_od_nhits_per_pmt_per_trigger);
-    MoveTracks(m_data->ODWCSimEvent_Triggered);
-    FinaliseSubEvents(m_data->ODWCSimEvent_Triggered);
+    ExecuteSubDet(m_data->ODWCSimEvent_Triggered, m_data->ODSamples, m_data->ODWCSimEvent_Raw);
   }
 
+  //Fill the tree with what we've just created
   m_event_tree->Fill();
 
   //make sure the triggers are reset for the next event
@@ -178,59 +175,127 @@ bool DataOut::Execute(){
   return true;
 }
 /////////////////////////////////////////////////////////////////
-void DataOut::CreateSubEvents(WCSimRootEvent * WCSimEvent)
-{
+void DataOut::ExecuteSubDet(WCSimRootEvent * wcsim_event, std::vector<SubSample> & samples, WCSimRootEvent * original_wcsim_event) {
+  //ReInitialise the WCSimRootEvent
+  // This clears the TObjArray of WCSimRootTrigger's,
+  // and creates a WCSimRootTrigger in the first slot
+  wcsim_event->ReInitialize();
+
+  //If there are multiple triggers in the event,
+  // create subevents (i.e. new WCSimRootTrigger's) in the WCSimRootEvent
+  //Also sets the time correctly
+  CreateSubEvents(wcsim_event);
+
+  //Get the difference between the WCSim "date" and the time of the first TriggerApp trigger,
+  // in order for the digits to have the correct absolute time.
+  // Also add the trigger offset from the config file
+  TimeDelta time_shift = GetOffset(original_wcsim_event);
+
+  //For every hit, if it's in a trigger window,
+  //add it to the appropriate WCSimRootTrigger in the WCSimRootEvent
+  FillDigits(wcsim_event, time_shift, samples);
+
+  //If this is an MC file, we also need to add
+  // - true tracks
+  // - true hits
+  if(m_data->IsMC)
+    AddTruthInfo(wcsim_event, original_wcsim_event, time_shift);
+
+  //Set some trigger header infromation that requires all the digits to be 
+  // present to calculate e.g. sumq
+  FinaliseSubEvents(wcsim_event);  
+}
+/////////////////////////////////////////////////////////////////
+void DataOut::CreateSubEvents(WCSimRootEvent * wcsim_event) {
   const int n = m_all_triggers->m_N;
   if (n==0) return;
 
-  // Move all digit times in trigger 0 to be relative to that trigger,
-  // i.e. move them by the difference of the old header date and the
-  // new taken from the trigger
-  WCSimRootTrigger * trig0 = WCSimEvent->GetTrigger(0);
-  // The new time
-  TimeDelta new_trigger_time = m_all_triggers->m_triggertime.at(0);
-  // The old time (stored in ns)
-  TimeDelta old_trigger_time = trig0->GetHeader()->GetDate() * TimeDelta::ns;
-  // The difference
-  TimeDelta time_shift = new_trigger_time - old_trigger_time;
-  m_ss << "DEBUG: Trigger date shift from " << old_trigger_time << " to " << new_trigger_time << ": " << time_shift;
-  StreamToLog(DEBUG2);
-
-  // Move all digits by the *negative* shift. If 5 seconds are added to the
-  // trigger time, the digit times (relative to the trigger) must be moved 5
-  // seonds back, so they remain at the same absolute time.
-  TClonesArray * digits = trig0->GetCherenkovDigiHits();
-  int ndigits_slots = trig0->GetNcherenkovdigihits_slots();
-  for(int i = 0; i < ndigits_slots; i++) {
-    WCSimRootCherenkovDigiHit * d = (WCSimRootCherenkovDigiHit*)digits->At(i);
-    if(!d)
-      continue;
-    double time = d->GetT();
-    m_ss << "DEBUG: Digit time before shift: " << time;
-    StreamToLog(DEBUG3);
-    time -= time_shift / TimeDelta::ns; // Hit times are stored in ns.
-    m_ss << "DEBUG: Digit time after shift: " << time;
-    StreamToLog(DEBUG3);
-    d->SetT(time);
-  }
-
-  // Change trigger times and create new SuEvents where necessary
+  // Change trigger times and create new SubEvents where necessary
   for(int i = 0; i < n; i++) {
     if(i)
-      WCSimEvent->AddSubEvent();
-    WCSimRootTrigger * trig = WCSimEvent->GetTrigger(i);
-    double offset = m_trigger_offset;
+      wcsim_event->AddSubEvent();
+    WCSimRootTrigger * trig = wcsim_event->GetTrigger(i);
     trig->SetHeader(m_event_num, 0, (m_all_triggers->m_triggertime.at(i) / TimeDelta::ns), i+1);
     trig->SetTriggerInfo(m_all_triggers->m_type.at(i), m_all_triggers->m_info.at(i));
     trig->SetMode(0);
   }//i
 }
 /////////////////////////////////////////////////////////////////
-void DataOut::FinaliseSubEvents(WCSimRootEvent * WCSimEvent)
-{
+TimeDelta DataOut::GetOffset(WCSimRootEvent * original_wcsim_event) {
+
+  TimeDelta time_shift(0);
+
+  if(m_data->IsMC) {
+    // Move all digit times in trigger 0 to be relative to that trigger,
+    // i.e. move them by the difference of the old header date and the
+    // new taken from the trigger
+    WCSimRootTrigger * trig0 = original_wcsim_event->GetTrigger(0);
+    // The new time
+    TimeDelta new_trigger_time = m_all_triggers->m_triggertime.at(0);
+    // The old time (stored in ns)
+    TimeDelta old_trigger_time = trig0->GetHeader()->GetDate() * TimeDelta::ns;
+    // The difference
+    TimeDelta time_shift = new_trigger_time - old_trigger_time;
+    m_ss << "DEBUG: Trigger date shift from " << old_trigger_time << " to " << new_trigger_time << ": " << time_shift;
+    StreamToLog(DEBUG2);
+  }
+
+  m_ss << "DEBUG: Adding additional user-defined time shift of "
+       << m_trigger_offset;
+  StreamToLog(DEBUG2);
+
+  time_shift += m_trigger_offset;
+  m_ss << "DEBUG: Total time shift is " << time_shift;
+  StreamToLog(DEBUG1);
+
+  return time_shift;
+}
+/////////////////////////////////////////////////////////////////
+void DataOut::FillDigits(WCSimRootEvent * wcsim_event, const TimeDelta & time_shift, std::vector<SubSample> & samples) {
+  unsigned int trigger_window_to_check;
+  TimeDelta time;
+  std::vector<int> photon_id_temp;
+  //Loop over all SubSamples
+  for(std::vector<SubSample>::iterator is=samples.begin(); is!=samples.end(); ++is){
+    // Make sure hit times are ordered in time
+    Log("WARN: TODO Sorting by time, and doing time window checks, will not be required after #49");
+    is->SortByTime();
+    //loop over every hit
+    const unsigned int ndigits = is->m_time.size();
+    for(int ihit = 0; ihit < ndigits; ihit++) {
+      time = is->m_time[ihit];
+      //hit time is before trigger window
+      if(time < m_all_triggers->m_starttime.at(trigger_window_to_check))
+	continue;
+      //hit time is after trigger window; check the next trigger window
+      else if(time > m_all_triggers->m_endtime.at(trigger_window_to_check)) {
+	ihit--;
+	trigger_window_to_check++;
+	if(trigger_window_to_check >= m_all_triggers->m_N)
+	  break;
+	continue;
+      }
+      //hit is in this window. Let's save it
+
+      // Move all digits by the *negative* shift. If 5 seconds are added to the
+      // trigger time, the digit times (relative to the trigger) must be moved 5
+      // seconds back, so they remain at the same absolute time.
+      time -= time_shift / TimeDelta::ns; //Is the time shift in the right place?
+      wcsim_event->GetTrigger(trigger_window_to_check)->AddCherenkovDigiHit(is->m_charge[ihit],
+									    time / TimeDelta::ns, //do i need to do any division here?
+									    is->m_PMTid[ihit],
+									    photon_id_temp);
+    }//ihit
+  }//loop over SubSamples
+}
+/////////////////////////////////////////////////////////////////
+void DataOut::AddTruthInfo(WCSimRootEvent * wcsim_event, WCSimRootEvent * original_wcsim_event, const TimeDelta & time_shift) {
+}
+/////////////////////////////////////////////////////////////////
+void DataOut::FinaliseSubEvents(WCSimRootEvent * wcsim_event) {
   const int n = m_all_triggers->m_N;
   for(int i = 0; i < n; i++) {
-    WCSimRootTrigger * trig = WCSimEvent->GetTrigger(i);
+    WCSimRootTrigger * trig = wcsim_event->GetTrigger(i);
     TClonesArray * digits = trig->GetCherenkovDigiHits();
     double sumq = 0;
     int ntubeshit = 0;
@@ -247,128 +312,6 @@ void DataOut::FinaliseSubEvents(WCSimRootEvent * WCSimEvent)
   }//i
 }
 /////////////////////////////////////////////////////////////////
-void DataOut::RemoveDigits(WCSimRootEvent * WCSimEvent, std::map<int, std::map<int, bool> > & NDigitPerPMTPerTriggerMap)
-{
-  if(!m_all_triggers->m_N) {
-    m_ss << "DEBUG: No trigger intervals to save";
-    StreamToLog(DEBUG1);
-  }
-  WCSimRootTrigger * trig0 = WCSimEvent->GetTrigger(0);
-  TClonesArray * digits = trig0->GetCherenkovDigiHits();
-  int ndigits = trig0->GetNcherenkovdigihits();
-  int ndigits_slots = trig0->GetNcherenkovdigihits_slots();
-  for(int i = 0; i < ndigits_slots; i++) {
-    WCSimRootCherenkovDigiHit * d = (WCSimRootCherenkovDigiHit*)digits->At(i);
-    if(!d)
-      continue;
-    // Absolute time of the digit
-    TimeDelta time = TimeDelta(d->GetT()) + TimeDelta(trig0->GetHeader()->GetDate());
-    int window = TimeInTriggerWindow(time);
-    int pmt = d->GetTubeId();
-    if(!m_save_only_failed_digits) {
-      m_ss << "DEBUG: Digit at time " << d->GetT() << " belongs to trigger " << window;
-      StreamToLog(DEBUG3);
-      //we're saving only things in the trigger window
-      if(window > 0 &&
-	 (m_save_multiple_hits_per_trigger ||
-	  (!m_save_multiple_hits_per_trigger && !NDigitPerPMTPerTriggerMap[pmt][window]))) {
-	//need to add digit to a new trigger window
-	//but not if we've already saved the 1 digit from this pmt in this window we're allowed
-	//need to store the digit time relative to the new trigger time
-        WCSimRootTrigger* new_trig = WCSimEvent->GetTrigger(window);
-        double old_time = trig0->GetHeader()->GetDate();
-        double new_time = new_trig->GetHeader()->GetDate();
-	d->SetT(d->GetT() + (old_time - new_time)); // Plus old minus new is correct!
-        // Add the digit
-	m_ss << "DEBUG: Adding digit to trigger " << window << " at new time " << d->GetT();
-	StreamToLog(DEBUG3);
-        new_trig->AddCherenkovDigiHit(d);
-      }
-      if(window ||
-	 (window == 0 && !m_save_multiple_hits_per_trigger && NDigitPerPMTPerTriggerMap[pmt][window])) {
-	//either not in a trigger window (window = -1)
-	//or not in the 0th trigger window (window >= 1)
-	//or in 0th window but we've already saved the 1 digit from this pmt in this window we're allowed
-	trig0->RemoveCherenkovDigiHit(d);
-      }
-      if(window >= 0) {
-	//save the fact that we've used this PMT
-	NDigitPerPMTPerTriggerMap[pmt][window] = true;
-      }
-    }//!m_save_only_failed_digits
-    else {
-      //We want to save digits that *haven't* passed any trigger
-      //To keep it simple:
-      // Remove anything that's in a trigger window
-      // Keep everything else in the 0th trigger
-      if(window >= 0)
-	trig0->RemoveCherenkovDigiHit(d);
-    }//m_save_only_failed_digits
-  }//i
-  m_ss << "INFO: RemoveDigits() has reduced number of digits in the 0th trigger from "
-     << ndigits << " to " << trig0->GetNcherenkovdigihits();
-  StreamToLog(INFO);
-}
-/////////////////////////////////////////////////////////////////
-void DataOut::MoveTracks(WCSimRootEvent * WCSimEvent)
-{
-  if(m_all_triggers->m_N < 2)
-    return;
-  WCSimRootTrigger * trig0 = WCSimEvent->GetTrigger(0);
-  TClonesArray * tracks = trig0->GetTracks();
-  int ntracks = trig0->GetNtrack();
-  int ntracks_slots = trig0->GetNtrack_slots();
-  for(int i = 0; i < ntracks_slots; i++) {
-    WCSimRootTrack * t = (WCSimRootTrack*)tracks->At(i);
-    if(!t)
-      continue;
-    // Absolute time of the track
-    TimeDelta time = TimeDelta(t->GetTime()) + TimeDelta(trig0->GetHeader()->GetDate());
-    int window = TimeInTriggerWindowNoDelete(time);
-    if(window > 0) {
-      m_ss << "DEBUG: Moving track from 0th  to " << window << " trigger";
-      StreamToLog(DEBUG3);
-      //need to add track to a new trigger window
-      WCSimEvent->GetTrigger(window)->AddTrack(t);
-      //and remove from the 0th
-      trig0->RemoveTrack(t);
-    }
-  }//i
-  m_ss << "INFO: MoveTracks() has reduced number of tracks in the 0th trigger from "
-     << ntracks << " to " << trig0->GetNtrack();
-  StreamToLog(INFO);
-}
-/////////////////////////////////////////////////////////////////
-int DataOut::TimeInTriggerWindow(TimeDelta time) {
-  for(unsigned int i = 0; i < m_all_triggers->m_N; i++) {
-    TimeDelta lo = m_all_triggers->m_starttime.at(i);
-    TimeDelta hi = m_all_triggers->m_endtime.at(i);
-    if(time >= lo && time <= hi)
-      return i;
-  }//it
-  return -1;
-}
-/////////////////////////////////////////////////////////////////
-unsigned int DataOut::TimeInTriggerWindowNoDelete(TimeDelta time) {
-  //we can't return -1 in this (i.e. we don't want to delete tracks)
-  //the logic is:
-  // if it's anytime before the 0th trigger + postrigger readout window, store in 0th trigger
-  // if it's anytime after the 0th trigger readout window and before the end of the 1st trigger readout window, store in the 1st trigger
-  // etc
-  //with the caveat that we don't create a WCSimRootTrigger just to store some tracks
-  // therefore return value is at maximum the number of triggers
-  const int N = m_all_triggers->m_N;
-  for(unsigned int i = 0; i < N; i++) {
-    TimeDelta hi = m_all_triggers->m_endtime.at(i);
-    if(time <= hi)
-      return i;
-  }//it
-  m_ss << "WARNING DataOut::TimeInTriggerWindowNoDelete() could not find a trigger that track with time " << time << " can live in. Returning maximum trigger number " << N - 1;
-  StreamToLog(WARN);
-  return N - 1;
-}
-
-/////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////
 
@@ -379,9 +322,8 @@ bool DataOut::Finalise(){
   }
 
   //multiple TFiles may be open. Ensure we save to the correct one
-  m_output_file.cd(TString::Format("%s:/", m_output_filename.c_str()));
+  m_output_file->cd(TString::Format("%s:/", m_output_filename.c_str()));
   m_event_tree->Write();
-  m_output_file.Close();
 
   delete m_event_tree;
   delete m_data->IDWCSimEvent_Triggered;
@@ -389,6 +331,9 @@ bool DataOut::Finalise(){
     delete m_data->ODWCSimEvent_Triggered;
 
   delete m_all_triggers;
+
+  m_output_file->Close();
+  delete m_output_file;
 
   if(m_stopwatch) {
     Log(m_stopwatch->Result("Finalise"), INFO, m_verbose);

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -138,10 +138,12 @@ bool DataOut::Execute(){
   // It puts hits into the output event in the earliest trigger they belong to
 
   //Fill the WCSimRootEvent with hit/trigger information, and truth information (if available)
-  ExecuteSubDet(m_data->IDWCSimEvent_Triggered, m_data->IDSamples, m_data->IDWCSimEvent_Raw);
-  if(m_data->HasOD) {
-    ExecuteSubDet(m_data->ODWCSimEvent_Triggered, m_data->ODSamples, m_data->ODWCSimEvent_Raw);
-  }
+  if(m_all_triggers->m_N) {
+    ExecuteSubDet(m_data->IDWCSimEvent_Triggered, m_data->IDSamples, m_data->IDWCSimEvent_Raw);
+    if(m_data->HasOD) {
+      ExecuteSubDet(m_data->ODWCSimEvent_Triggered, m_data->ODSamples, m_data->ODWCSimEvent_Raw);
+    }
+  }//>=1 trigger found
 
   //Fill the tree with what we've just created
   m_event_tree->Fill();

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -266,12 +266,13 @@ void DataOut::FillHits(WCSimRootEvent * wcsim_event, const TimeDelta & time_shif
 	if(trigger_window_to_check >= m_all_triggers->m_N) break;
 	continue;
       }
-      //hit is in this window. Let's save it
 
       // Move all hits by the *negative* shift. If 5 seconds are added to the
       // trigger time, the hit times (relative to the trigger) must be moved 5
       // seconds back, so they remain at the same absolute time.
       time -= time_shift / TimeDelta::ns; //Is the time shift in the right place?
+
+      //hit is in this window. Let's save it
       wcsim_event->GetTrigger(trigger_window_to_check)->AddCherenkovDigiHit(is->m_charge[ihit],
 									    time / TimeDelta::ns, //do i need to do any division here?
 									    is->m_PMTid[ihit],

--- a/UserTools/DataOut/DataOut.cpp
+++ b/UserTools/DataOut/DataOut.cpp
@@ -245,15 +245,24 @@ void DataOut::FillHits(WCSimRootEvent * wcsim_event, const TimeDelta & time_shif
     is->SortByTime();
     //loop over every hit
     const unsigned int nhits = is->m_time.size();
+    int counter = 0;
     for(int ihit = 0; ihit < nhits; ihit++) {
       time = is->m_time[ihit];
+      m_ss << "Hit " << ihit << " is at time " << time << std::endl
+	   << "Checking hit is in range [" << m_all_triggers->m_starttime.at(trigger_window_to_check)
+	   << ", " << m_all_triggers->m_endtime.at(trigger_window_to_check) << "]";
+      StreamToLog(DEBUG3);
+      
       //hit time is before trigger window
-      if(time < m_all_triggers->m_starttime.at(trigger_window_to_check))
+      if(time < m_all_triggers->m_starttime.at(trigger_window_to_check)) {
+	Log("Too early", DEBUG3, m_verbose);
 	continue;
+      }
       //hit time is after trigger window; check the next trigger window
       else if(time > m_all_triggers->m_endtime.at(trigger_window_to_check)) {
 	ihit--;
 	trigger_window_to_check++;
+	Log("Too late", DEBUG3, m_verbose);
 	if(trigger_window_to_check >= m_all_triggers->m_N)
 	  break;
 	continue;
@@ -268,6 +277,8 @@ void DataOut::FillHits(WCSimRootEvent * wcsim_event, const TimeDelta & time_shif
 									    time / TimeDelta::ns, //do i need to do any division here?
 									    is->m_PMTid[ihit],
 									    photon_id_temp);
+      m_ss << "Saved hit " << counter++;
+      StreamToLog(DEBUG3);
     }//ihit
   }//loop over SubSamples
 }

--- a/UserTools/DataOut/DataOut.h
+++ b/UserTools/DataOut/DataOut.h
@@ -33,17 +33,17 @@ class DataOut: public Tool {
   /// Also sets the time correctly
   void CreateSubEvents(WCSimRootEvent * wcsim_event);
   /// Get the difference between the WCSim "date" and the time of the first TriggerApp trigger,
-  ///  in order for the digits to have the correct absolute time.
+  ///  in order for the hits to have the correct absolute time.
   ///  Also add the trigger offset from the config file
   TimeDelta GetOffset(WCSimRootEvent * original_wcsim_event = 0);
   /// For every hit, if it's in a trigger window,
   ///  add it to the appropriate WCSimRootTrigger in the WCSimRootEvent
-  void FillDigits(WCSimRootEvent * wcsim_event, const TimeDelta & time_shift, std::vector<SubSample> & samples);
+  void FillHits(WCSimRootEvent * wcsim_event, const TimeDelta & time_shift, std::vector<SubSample> & samples);
   /// If this is an MC file, we also need to add
   /// - true tracks
   /// - true hits
   void AddTruthInfo(WCSimRootEvent * wcsim_event, WCSimRootEvent * original_wcsim_event, const TimeDelta & time_shift);
-  //Set some trigger header infromation that requires all the digits to be 
+  //Set some trigger header infromation that requires all the hits to be 
   // present to calculate e.g. sumq
   void FinaliseSubEvents(WCSimRootEvent * wcsim_event);
 
@@ -58,20 +58,16 @@ class DataOut: public Tool {
 
   /// Combined list of triggers from all sources (ID+OD)
   TriggerInfo * m_all_triggers;
-  /// A time used to offset all digit times. Set by config file
+  /// A time used to offset all hit times. Set by config file
   TimeDelta m_trigger_offset;
 
   /// Current event number
   int m_event_num;
 
-  /// If true, saves digits that failed the trigger, rather those that passed
-  bool m_save_only_failed_digits;
-  /// If false, only 1 digit is allowed to be saved per trigger, rather than all digits from that trigger
+  /// If true, saves hits that failed the trigger, rather those that passed
+  bool m_save_only_failed_hits;
+  /// If false, only 1 hit is allowed to be saved per trigger, rather than all hits from that trigger
   bool m_save_multiple_hits_per_trigger;
-  /// For each PMT, for each trigger, has an ID digit been saved already?
-  std::map<int, std::map<int, bool> > m_id_nhits_per_pmt_per_trigger;
-  /// For each PMT, for each trigger, has an OD digit been saved already?
-  std::map<int, std::map<int, bool> > m_od_nhits_per_pmt_per_trigger;
 
   /// The stopwatch, if we're using one
   util::Stopwatch * m_stopwatch;

--- a/UserTools/DataOut/DataOut.h
+++ b/UserTools/DataOut/DataOut.h
@@ -34,37 +34,51 @@ class DataOut: public Tool {
   int  TimeInTriggerWindow(TimeDelta time);
   unsigned int TimeInTriggerWindowNoDelete(TimeDelta time);
 
-  std::string fOutFilename;
-  TFile fOutFile;
-  TTree * fTreeEvent;
-  TTree * fTreeGeom;
-  TTree * fTreeOptions;
-  TString * fWCSimFilename;
+  /// Output ROOT filename that this tool RECREATE's
+  std::string m_output_filename;
+  /// Output ROOT file
+  TFile m_output_file;
+  /// Tree contain WCSimRootEvent(s), and the original WCSim filename / event number
+  TTree * m_event_tree;
+  TTree * m_tree_geom;
+  TTree * m_tree_options;
 
-  TriggerInfo * fTriggers;
-  double fTriggerOffset;
+  /// Combined list of triggers from all sources (ID+OD)
+  TriggerInfo * m_all_triggers;
+  /// A time used to offset all digit times. Set by config file
+  double m_trigger_offset;
 
-  int fEvtNum;
+  /// Current event number
+  int m_event_num;
 
-  bool fSaveOnlyFailedDigits;
-  bool fSaveMultiDigiPerTrigger;
-  std::map<int, std::map<int, bool> > fIDNDigitPerPMTPerTriggerMap;
-  std::map<int, std::map<int, bool> > fODNDigitPerPMTPerTriggerMap;
+  /// If true, saves digits that failed the trigger, rather those that passed
+  bool m_save_only_failed_digits;
+  /// If false, only 1 digit is allowed to be saved per trigger, rather than all digits from that trigger
+  bool m_save_multiple_hits_per_trigger;
+  /// For each PMT, for each trigger, has an ID digit been saved already?
+  std::map<int, std::map<int, bool> > m_id_nhits_per_pmt_per_trigger;
+  /// For each PMT, for each trigger, has an OD digit been saved already?
+  std::map<int, std::map<int, bool> > m_od_nhits_per_pmt_per_trigger;
 
   /// The stopwatch, if we're using one
   util::Stopwatch * m_stopwatch;
   /// Image filename to save the histogram to, if required
   std::string m_stopwatch_file;
 
+  /// Verbosity level, as defined in tool parameter file
   int m_verbose;
 
-  std::stringstream ss;
+  /// For easy formatting of Log messages
+  std::stringstream m_ss;
 
+  /// Print the current value of the streamer at the set log level,
+  ///  then clear the streamer
   void StreamToLog(int level) {
-    Log(ss.str(), level, m_verbose);
-    ss.str("");
+    Log(m_ss.str(), level, m_verbose);
+    m_ss.str("");
   }
 
+  /// Log level enumerations
   enum LogLevel {FATAL=-1, ERROR=0, WARN=1, INFO=2, DEBUG1=3, DEBUG2=4, DEBUG3=5};
 };
 

--- a/UserTools/DataOut/DataOut.h
+++ b/UserTools/DataOut/DataOut.h
@@ -37,7 +37,7 @@ class DataOut: public Tool {
   TimeDelta GetOffset(WCSimRootEvent * original_wcsim_event = 0);
   /// For every hit, if it's in a trigger window,
   ///  add it to the appropriate WCSimRootTrigger in the WCSimRootEvent
-  void FillHits(WCSimRootEvent * wcsim_event, const TimeDelta & time_shift, std::vector<SubSample> & samples);
+  void FillHits(WCSimRootEvent * wcsim_event, std::vector<SubSample> & samples);
   /// If this is an MC file, we also need to add
   /// - true tracks
   /// - true hits

--- a/UserTools/DataOut/DataOut.h
+++ b/UserTools/DataOut/DataOut.h
@@ -53,8 +53,6 @@ class DataOut: public Tool {
   TFile * m_output_file;
   /// Tree contain WCSimRootEvent(s), and the original WCSim filename / event number
   TTree * m_event_tree;
-  TTree * m_tree_geom;
-  TTree * m_tree_options;
 
   /// Combined list of triggers from all sources (ID+OD)
   TriggerInfo * m_all_triggers;

--- a/UserTools/DataOut/DataOut.h
+++ b/UserTools/DataOut/DataOut.h
@@ -32,9 +32,8 @@ class DataOut: public Tool {
   ///  create subevents (i.e. new WCSimRootTrigger's) in the WCSimRootEvent
   /// Also sets the time correctly
   void CreateSubEvents(WCSimRootEvent * wcsim_event);
-  /// Get the difference between the WCSim "date" and the time of the first TriggerApp trigger,
-  ///  in order for the hits to have the correct absolute time.
-  ///  Also add the trigger offset from the config file
+  //Get the WCSim "date", used later to give the hits the correct absolute time.
+  // Also add the trigger offset from the config file
   TimeDelta GetOffset(WCSimRootEvent * original_wcsim_event = 0);
   /// For every hit, if it's in a trigger window,
   ///  add it to the appropriate WCSimRootTrigger in the WCSimRootEvent

--- a/UserTools/DataOut/DataOut.h
+++ b/UserTools/DataOut/DataOut.h
@@ -26,18 +26,31 @@ class DataOut: public Tool {
 
 
  private:
-  void CreateSubEvents(WCSimRootEvent * WCSimEvent);
-  void FinaliseSubEvents(WCSimRootEvent * WCSimEvent);
-  void RemoveDigits(WCSimRootEvent * WCSimEvent,
-		    std::map<int, std::map<int, bool> > & NDigitPerPMTPerTriggerMap);
-  void MoveTracks(WCSimRootEvent * WCSimEvent);
-  int  TimeInTriggerWindow(TimeDelta time);
-  unsigned int TimeInTriggerWindowNoDelete(TimeDelta time);
+  /// Runs other methods to take information from the DataModel and create/populate the WCSimRootEvent
+  void ExecuteSubDet(WCSimRootEvent * wcsim_event, std::vector<SubSample> & samples, WCSimRootEvent * original_wcsim_event = 0);
+  /// If there are multiple triggers in the event,
+  ///  create subevents (i.e. new WCSimRootTrigger's) in the WCSimRootEvent
+  /// Also sets the time correctly
+  void CreateSubEvents(WCSimRootEvent * wcsim_event);
+  /// Get the difference between the WCSim "date" and the time of the first TriggerApp trigger,
+  ///  in order for the digits to have the correct absolute time.
+  ///  Also add the trigger offset from the config file
+  TimeDelta GetOffset(WCSimRootEvent * original_wcsim_event = 0);
+  /// For every hit, if it's in a trigger window,
+  ///  add it to the appropriate WCSimRootTrigger in the WCSimRootEvent
+  void FillDigits(WCSimRootEvent * wcsim_event, const TimeDelta & time_shift, std::vector<SubSample> & samples);
+  /// If this is an MC file, we also need to add
+  /// - true tracks
+  /// - true hits
+  void AddTruthInfo(WCSimRootEvent * wcsim_event, WCSimRootEvent * original_wcsim_event, const TimeDelta & time_shift);
+  //Set some trigger header infromation that requires all the digits to be 
+  // present to calculate e.g. sumq
+  void FinaliseSubEvents(WCSimRootEvent * wcsim_event);
 
   /// Output ROOT filename that this tool RECREATE's
   std::string m_output_filename;
   /// Output ROOT file
-  TFile m_output_file;
+  TFile * m_output_file;
   /// Tree contain WCSimRootEvent(s), and the original WCSim filename / event number
   TTree * m_event_tree;
   TTree * m_tree_geom;
@@ -46,7 +59,7 @@ class DataOut: public Tool {
   /// Combined list of triggers from all sources (ID+OD)
   TriggerInfo * m_all_triggers;
   /// A time used to offset all digit times. Set by config file
-  double m_trigger_offset;
+  TimeDelta m_trigger_offset;
 
   /// Current event number
   int m_event_num;

--- a/UserTools/WCSimReader/WCSimReader.cpp
+++ b/UserTools/WCSimReader/WCSimReader.cpp
@@ -64,10 +64,14 @@ bool WCSimReader::Initialise(std::string configfile, DataModel &data){
   m_chain_opt->GetEntry(0);
   m_wcsim_event_ID = 0;
   m_chain_event->SetBranchAddress("wcsimrootevent",   &m_wcsim_event_ID);
+  // Force deletion to prevent memory leak
+  m_chain_event->GetBranch("wcsimrootevent")->SetAutoDelete(kTRUE);
   if(m_wcsim_opt->GetGeomHasOD()) {
     Log("INFO: The geometry has an OD. Will add OD digits to m_data", INFO, m_verbose);
     m_wcsim_event_OD = 0;
     m_chain_event->SetBranchAddress("wcsimrootevent_OD",   &m_wcsim_event_OD);
+    // Force deletion to prevent memory leak
+    m_chain_event->GetBranch("wcsimrootevent_OD")->SetAutoDelete(kTRUE);
     m_data->HasOD = true;
   }
   else {

--- a/UserTools/WCSimReader/WCSimReader.cpp
+++ b/UserTools/WCSimReader/WCSimReader.cpp
@@ -185,8 +185,7 @@ bool WCSimReader::CompareTree(TChain * chain, int mode)
     modestr = "WCSimRootOptions";
   }
   else if(mode == 1) {
-    //wcsim_geom_0 = new WCSimRootGeom(*m_wcsim_geom); //this operation doesn't work in WCSim
-    Log("WARN: geometry not being checked for equality between files. TODO - uncomment this line after WCSim PR 281", WARN, m_verbose);
+    wcsim_geom_0 = new WCSimRootGeom(*m_wcsim_geom); //this operation doesn't work in WCSim
     modestr = "WCSimRootGeom";
   }
   //loop over all the other entries
@@ -212,7 +211,7 @@ bool WCSimReader::CompareTree(TChain * chain, int mode)
       //WCSimWCAddDarkNoise
       std::vector<string> pmtlocs;
       pmtlocs.push_back("tank");
-      pmtlocs.push_back("OD");
+      if(m_data->HasOD) pmtlocs.push_back("OD");
       for(unsigned int i = 0; i < pmtlocs.size(); i++) {
 	diff_file = diff_file || CompareVariable(wcsim_opt_0->GetPMTDarkRate(pmtlocs.at(i)),
 						 m_wcsim_opt->GetPMTDarkRate(pmtlocs.at(i)),
@@ -282,8 +281,7 @@ bool WCSimReader::CompareTree(TChain * chain, int mode)
 
     }//mode == 0
     else if(mode == 1) {
-      //diff_file = !wcsim_geom_0->CompareAllVariables(m_wcsim_geom);
-      Log("WARN: geometry not being checked for equality between files. TODO - uncomment this line after WCSim PR 281", WARN, m_verbose);
+      diff_file = !wcsim_geom_0->CompareAllVariables(m_wcsim_geom);
     }//mode == 1
     if(diff_file) {
       m_ss << "ERROR: Difference between " << modestr << " tree between input file 0 and " << i;
@@ -295,8 +293,7 @@ bool WCSimReader::CompareTree(TChain * chain, int mode)
     delete wcsim_opt_0;
   }
   else if(mode == 1) {
-    //delete wcsim_geom_0;
-    Log("WARN: geometry not being checked for equality between files. TODO - uncomment this line after WCSim PR 281", WARN, m_verbose);
+    delete wcsim_geom_0;
   }
   if(diff) {
     m_ss << "ERROR: Difference between " << modestr << " trees";

--- a/UserTools/WCSimReader/WCSimReader.cpp
+++ b/UserTools/WCSimReader/WCSimReader.cpp
@@ -59,14 +59,14 @@ bool WCSimReader::Initialise(std::string configfile, DataModel &data){
     return false;
 
   //set branch addresses
-  m_wcsim_opt = new WCSimRootOptions();
+  m_wcsim_opt = 0;
   m_chain_opt  ->SetBranchAddress("wcsimrootoptions", &m_wcsim_opt);
   m_chain_opt->GetEntry(0);
-  m_wcsim_event_ID = new WCSimRootEvent();
+  m_wcsim_event_ID = 0;
   m_chain_event->SetBranchAddress("wcsimrootevent",   &m_wcsim_event_ID);
   if(m_wcsim_opt->GetGeomHasOD()) {
     Log("INFO: The geometry has an OD. Will add OD digits to m_data", INFO, m_verbose);
-    m_wcsim_event_OD = new WCSimRootEvent();
+    m_wcsim_event_OD = 0;
     m_chain_event->SetBranchAddress("wcsimrootevent_OD",   &m_wcsim_event_OD);
     m_data->HasOD = true;
   }
@@ -74,7 +74,7 @@ bool WCSimReader::Initialise(std::string configfile, DataModel &data){
     m_wcsim_event_OD = 0;
     m_data->HasOD = false;
   }
-  m_wcsim_geom = new WCSimRootGeom();
+  m_wcsim_geom = 0;
   m_chain_geom ->SetBranchAddress("wcsimrootgeom",    &m_wcsim_geom);
 
   //set number of events
@@ -98,8 +98,8 @@ bool WCSimReader::Initialise(std::string configfile, DataModel &data){
   std::cerr << "OD PMTs are not currently stored in WCSimRootGeom. When they are TODO fill IDGeom & ODGeom depending on where the PMT is" << std::endl;
   m_chain_geom->GetEntry(0);
   for(int ipmt = 0; ipmt < m_wcsim_geom->GetWCNumPMT(); ipmt++) {
-    WCSimRootPMT pmt = m_wcsim_geom->GetPMT(ipmt);
-    PMTInfo pmt_light(pmt.GetTubeNo(), pmt.GetPosition(0), pmt.GetPosition(1), pmt.GetPosition(2));
+    const WCSimRootPMT * pmt = m_wcsim_geom->GetPMTPtr(ipmt);
+    PMTInfo pmt_light(pmt->GetTubeNo(), pmt->GetPosition(0), pmt->GetPosition(1), pmt->GetPosition(2));
     m_data->IDGeom.push_back(pmt_light);
   }//ipmt
 
@@ -107,13 +107,6 @@ bool WCSimReader::Initialise(std::string configfile, DataModel &data){
   m_data->WCSimGeomTree = m_chain_geom;
   m_data->WCSimOptionsTree = m_chain_opt;
   m_data->WCSimEventTree = m_chain_event;
-  m_data->IDWCSimEvent_Raw = m_wcsim_event_ID;
-  m_data->ODWCSimEvent_Raw = m_wcsim_event_OD;
-
-  //setup the TObjArray to store the filenames
-  //int nfiles = m_chain_event->GetListOfFiles()->GetEntries();
-  m_data->CurrentWCSimFiles = new TObjArray();
-  m_data->CurrentWCSimFiles->SetOwner(true);
 
   //store the relevant options
   m_data->IsMC = true;
@@ -347,15 +340,18 @@ bool WCSimReader::Execute(){
     return false;
   }
 
+  //make sure the event is pointed to in the data model
+  m_data->IDWCSimEvent_Raw = m_wcsim_event_ID;
+  m_data->ODWCSimEvent_Raw = m_wcsim_event_OD;
+
   //store the WCSim filename(s) and event number(s) for the current event(s)
-  m_data->CurrentWCSimFiles->Clear();
-  m_data->CurrentWCSimEventNums.clear();
-  TObjString * fname = new TObjString(m_chain_event->GetFile()->GetName());
-  int event_in_wcsim_file = m_current_event_num - m_chain_event->GetTreeOffset()[m_chain_event->GetTreeNumber()];
-  m_ss << "DEBUG: Current event is event " << event_in_wcsim_file << " from WCSim file " << fname->String() << " " << m_chain_event->GetTreeOffset()[m_chain_event->GetTreeNumber()];
+  m_data->CurrentWCSimFile.String() = m_chain_event->GetFile()->GetName();
+  m_data->CurrentWCSimEventNum      = m_current_event_num 
+    - m_chain_event->GetTreeOffset()[m_chain_event->GetTreeNumber()];
+  m_ss << "DEBUG: Current event is event " << m_data->CurrentWCSimEventNum
+       << " from WCSim file " << m_data->CurrentWCSimFile.String()
+       << " Tree offset is " << m_chain_event->GetTreeOffset()[m_chain_event->GetTreeNumber()];
   StreamToLog(DEBUG1);
-  m_data->CurrentWCSimFiles->Add(fname);
-  m_data->CurrentWCSimEventNums.push_back(event_in_wcsim_file);
 
   //store digit info in the transient data model
   //ID
@@ -473,17 +469,9 @@ bool WCSimReader::Finalise(){
   m_ss << "INFO: Read " << m_current_event_num << " WCSim events";
   StreamToLog(INFO);
 
-  delete m_data->CurrentWCSimFiles;
-
   delete m_chain_opt;
   delete m_chain_event;
   delete m_chain_geom;
-
-  delete m_wcsim_opt;
-  delete m_wcsim_event_ID;
-  if(m_wcsim_event_OD)
-    delete m_wcsim_event_OD;
-  delete m_wcsim_geom;
 
   if(m_stopwatch) {
     Log(m_stopwatch->Result("Finalise"), INFO, m_verbose);

--- a/configfiles/WCSimReaderTest/DataOutToolConfig
+++ b/configfiles/WCSimReaderTest/DataOutToolConfig
@@ -1,7 +1,7 @@
 outfilename triggered.root
-save_multiple_digits_per_trigger 1
+save_multiple_hits_per_trigger 1
 trigger_offset 950
-save_only_failed_digits 0
+save_only_failed_hits 0
 use_stopwatch 1
 #stopwatch_file dataout_stopwatch.pdf
 verbose 3


### PR DESCRIPTION
* WCSimReader was leaking badly; fixed with `TBranch::SetAutoDelete(kTRUE)`
* `DataOut::Finalise()` was seg faulting. Fixed by making the `TFile` a `TFile *` (yes I don't understand either...)
* The event num/filename from the original root file is now a single entry, rather than multiple (now we can have big events in WCSim, don't have to implement event stacking in TriggerApplication). This fixes a memory leak there
* DataOut is rewritten. Instead of hacking together a WCSimRootEvent out of the ashes of the input one, it creates a new one and fills it sensibly
  - The output is _almost_ identical to the old version. In a test of 10 events, 3 aren't completly identical to the old version, and they seem to be hits at the edge of the trigger readout window. I'm reluctant to spend more time on this, since #49 is going to make finding hit times obsolete anyway (or at least, pushes the problem into a different tool...)
  - The file looks mostly like a WCSim file, however the true tracks are all in trigger 0 (rather than spread around the triggers like WCSim does). I can probably do what WCSim does, but to me that's a more confusing layout. Thoughts?
  - It should now work for data (i.e. when not using WCSimReader), with the caveat that the geometry tree is a "todo"
* DataOut now adheres to the new coding conventions, and tries to use "hit" instead of "digit" for consistency with the rest of TriggerApplication

Note this requires the WCSim branch https://github.com/tdealtry/WCSim/tree/leak