### PR TITLE
Implement a first_event config variable in WCSimReader

### DIFF
--- a/UserTools/WCSimReader/README.md
+++ b/UserTools/WCSimReader/README.md
@@ -55,5 +55,5 @@ verbose LEVEL
 * `infile` File path to WCSim root file. Can use wildcards to pickup multiple files
 * `filelist` File path to a text file with a filepath to a WCSim root file on each line. Can also contain wildcards
 * `nevents` will read only this number of events. If `N <= 0`, read all. If `N > number of available events`, read all.
-* `first_event` will skip to this event number. If `N > number of available events`, will read the final event only
+* `first_event` will skip to this event number. If `N > number of available events`, will read the final event only. If `N < 0`, will set it to 0. Default is 0
 * `verbose` Verbosity level. Runs from 0 (low verbosity) to 9 (high verbosity)

--- a/UserTools/WCSimReader/README.md
+++ b/UserTools/WCSimReader/README.md
@@ -48,10 +48,12 @@ WCSimReader
 infile /path/to/file(s)
 filelist /path/to/txt/file/list
 nevents N
+first_event N
 verbose LEVEL
 ```
 
 * `infile` File path to WCSim root file. Can use wildcards to pickup multiple files
 * `filelist` File path to a text file with a filepath to a WCSim root file on each line. Can also contain wildcards
 * `nevents` will read only this number of events. If `N <= 0`, read all. If `N > number of available events`, read all.
+* `first_event` will skip to this event number. If `N > number of available events`, will read the final event only
 * `verbose` Verbosity level. Runs from 0 (low verbosity) to 9 (high verbosity)

--- a/UserTools/WCSimReader/WCSimReader.cpp
+++ b/UserTools/WCSimReader/WCSimReader.cpp
@@ -80,6 +80,10 @@ bool WCSimReader::Initialise(std::string configfile, DataModel &data){
     m_ss << "WARN: first_event set to value more than the number of events in the file. Reading just the last event in the file, number: " << m_first_event_num;
     StreamToLog(WARN);
   }
+  else if(m_first_event_num < 0) {
+    m_first_event_num = 0;
+    Log("WARN: first_event set to negative value. Set to 0", WARN, m_verbose);
+  }
   m_current_event_num = m_first_event_num;
 
   //ensure that the geometry & options are the same for each file

--- a/UserTools/WCSimReader/WCSimReader.h
+++ b/UserTools/WCSimReader/WCSimReader.h
@@ -63,6 +63,8 @@ class WCSimReader: public Tool {
 
   /// The current WCSim event number
   long int m_current_event_num;
+  /// The first WCSim event number to read
+  long int m_first_event_num;
   /// The total number of events in m_chain_event
   long int m_n_events;
 

--- a/configfiles/WCSimBONSAI/WCSimReaderToolConfig
+++ b/configfiles/WCSimBONSAI/WCSimReaderToolConfig
@@ -3,4 +3,5 @@
 infile $WCSIMDIR/wcsim.root
 #filelist wcsimfilelist
 nevents -1
+first_event 0
 verbose 3

--- a/configfiles/WCSimReaderTest/WCSimReaderToolConfig
+++ b/configfiles/WCSimReaderTest/WCSimReaderToolConfig
@@ -3,4 +3,5 @@
 infile $WCSIMDIR/wcsim.root
 #filelist wcsimfilelist
 nevents -1
+first_event 0
 verbose 3


### PR DESCRIPTION
Will be useful for debugging dodgy events