### PR TITLE
DataOut fix

### DIFF
--- a/DataModel/SubSample.cpp
+++ b/DataModel/SubSample.cpp
@@ -192,12 +192,12 @@ void SubSample::TellMeAboutTheTriggers(const TriggerInfo & triggers, const int v
   std::stringstream ss;
   for(unsigned int itrigger = m_start_trigger; itrigger < num_triggers; itrigger++) {
     util::Window readout(itrigger,
-			 triggers.m_readout_start_time[itrigger] - m_timestamp,
-			 triggers.m_readout_end_time[itrigger]   - m_timestamp);
+			 triggers.m_readout_start_time[itrigger],
+			 triggers.m_readout_end_time[itrigger]);
     readout_windows[itrigger - m_start_trigger] = readout;
     util::Window mask(itrigger,
-		      triggers.m_mask_start_time[itrigger] - m_timestamp,
-		      triggers.m_mask_end_time[itrigger]   - m_timestamp);
+		      triggers.m_mask_start_time[itrigger],
+		      triggers.m_mask_end_time[itrigger]);
     mask_windows[itrigger - m_start_trigger] = mask;
     if(util::DEBUG2 <= verbose) {
       ss << "DEBUG: Trigger: " << itrigger

--- a/UserTools/nhits/nhits.cpp
+++ b/UserTools/nhits/nhits.cpp
@@ -106,8 +106,8 @@ bool NHits::Execute(){
       m_data->IDTriggers.AddTrigger(kTriggerNDigits,
                                     TimeDelta(trigger_ts[i]) - m_trigger_save_window_pre + is->m_timestamp,
                                     TimeDelta(trigger_ts[i]) + m_trigger_save_window_post + is->m_timestamp,
-                                    TimeDelta(trigger_ts[i]) - m_trigger_save_window_pre + is->m_timestamp,
-                                    TimeDelta(trigger_ts[i]) + m_trigger_save_window_post + is->m_timestamp,
+                                    TimeDelta(trigger_ts[i]) - m_trigger_mask_window_pre + is->m_timestamp,
+                                    TimeDelta(trigger_ts[i]) + m_trigger_mask_window_post + is->m_timestamp,
                                     TimeDelta(trigger_ts[i]) + is->m_timestamp,
                                     std::vector<float>(1, trigger_ns[i]));
 
@@ -153,7 +153,6 @@ void NHits::AlgNDigits(const SubSample * sample)
   int first_digit_in_window = 0;
   for(;current_digit < ndigits; ++current_digit) {
     // Update first digit in trigger window
-
     if( !m_degrade_CPU ){
       TimeDelta::short_time_t digit_time = sample->m_time.at(current_digit);
       while(TimeDelta(sample->m_time[first_digit_in_window]) < TimeDelta(digit_time) - m_trigger_search_window){
@@ -196,8 +195,8 @@ void NHits::AlgNDigits(const SubSample * sample)
       triggers->AddTrigger(kTriggerNDigits,
 			   triggertime - m_trigger_save_window_pre + sample->m_timestamp,
 			   triggertime + m_trigger_save_window_post + sample->m_timestamp,
-			   triggertime - m_trigger_save_window_pre + sample->m_timestamp,
-			   triggertime + m_trigger_save_window_post + sample->m_timestamp,
+			   triggertime - m_trigger_mask_window_pre + sample->m_timestamp,
+			   triggertime + m_trigger_mask_window_post + sample->m_timestamp,
 			   triggertime + sample->m_timestamp,
 			   std::vector<float>(1, n_digits));
     }


### PR DESCRIPTION
When there was not a trigger for the current event, DataOut would write a copy of the last triggered event

This fixes it, by
- For MC, filling the TTree with the empty event (with associated truth info)
- For data, not filling the TTree unless there are triggers found