### PR TITLE
Exit if not using a NoTrigger input file

### DIFF
--- a/UserTools/WCSimReader/WCSimReader.cpp
+++ b/UserTools/WCSimReader/WCSimReader.cpp
@@ -384,6 +384,9 @@ bool WCSimReader::Execute(){
   }
   else {
     //a trigger has been run, so we need to get all digits from all WCSim event triggers, and fill in the relevant TriggerInfo
+    Log("INFO: Reading in a file that has already been triggered", INFO, m_verbose);
+    Log("FATAL: This is not correctly implemented at the moment. Exiting", FATAL, m_verbose);
+    return false;
     SubSample subid_all;
     for(int itrigger = 0; itrigger < m_wcsim_event_ID->GetNumberOfEvents(); itrigger++) {
       m_wcsim_trigger = m_wcsim_event_ID->GetTrigger(itrigger);


### PR DESCRIPTION
When running with an input file that has already been triggered, the logic isn't right in some way and we get 2 triggers (some with no hits in) on events we expect just one trigger

Since it's not something we currently use, I've made it a fatal error to use an input WCSim file that isn't run with the NoTrigger trigger. This will prevent problems

Leaving the (incomplete) code there for running with an already-triggered file, in case it is something that will be useful in the future