### PR TITLE
Fix the trigger time for NHITS CPU

### DIFF
--- a/UserTools/nhits/nhits.cpp
+++ b/UserTools/nhits/nhits.cpp
@@ -193,11 +193,11 @@ void NHits::AlgNDigits(const SubSample * sample)
       StreamToLog(DEBUG2);
       
       triggers->AddTrigger(kTriggerNDigits,
-			   triggertime - m_trigger_save_window_pre + sample->m_timestamp,
-			   triggertime + m_trigger_save_window_post + sample->m_timestamp,
-			   triggertime - m_trigger_mask_window_pre + sample->m_timestamp,
-			   triggertime + m_trigger_mask_window_post + sample->m_timestamp,
-			   triggertime + sample->m_timestamp,
+			   triggertime - m_trigger_save_window_pre,
+			   triggertime + m_trigger_save_window_post,
+			   triggertime - m_trigger_mask_window_pre,
+			   triggertime + m_trigger_mask_window_post,
+			   triggertime,
 			   std::vector<float>(1, n_digits));
     }
   }//loop over Digits


### PR DESCRIPTION
`-sample->m_timestamp` is not required, because `triggertime` is already an absolute time