### PR TITLE
Initialise to 0 m_first_unique and m_timestamp in the default (and re…

### DIFF
--- a/DataModel/SubSample.cpp
+++ b/DataModel/SubSample.cpp
@@ -3,6 +3,13 @@
 
 #include <algorithm>
 
+SubSample::SubSample() {
+  // Assign default values
+  m_timestamp = 0;
+  m_first_unique = 0;
+  m_start_trigger = 0;
+}
+
 SubSample::SubSample(std::vector<int> PMTid, std::vector<TimeDelta::short_time_t> time, std::vector<float> charge, TimeDelta timestamp){
   // If charge vector is empty, fill with 0s
   if (charge.size() == 0){

--- a/DataModel/SubSample.h
+++ b/DataModel/SubSample.h
@@ -12,7 +12,7 @@ class SubSample{
 
  public:
 
-  SubSample() : m_start_trigger(0) {};
+  SubSample();
 
   /// Deprecated constructor, use empty constructor and Append instead.
   __attribute__((deprecated))


### PR DESCRIPTION
…commended) SubSample constructor

This was causing some odd behaviour, related to run conditions in BONSAI/FLOWER. e.g. when running with toolchain verbosity < 4, it would be initialised to some large number and no hits would be found in the trigger. (But would work fine for verbosity >= 4)