### PR TITLE
Make all toolchains at least verbosity level 4

### DIFF
--- a/configfiles/SNTriggering/ToolChainConfig
+++ b/configfiles/SNTriggering/ToolChainConfig
@@ -1,7 +1,7 @@
 #ToolChain dynamic setup file
 
 ##### Runtime Paramiters #####
-verbose 2 ## Verbosity level of ToolChain
+verbose 4 ## Verbosity level of ToolChain
 error_level 0 # 0= do not exit, 1= exit on unhandeled errors only, 2= exit on unhandeled errors and handeled errors
 attempt_recover 1 ## 1= will attempt to finalise if an execute fails
 remote_port 24002

--- a/configfiles/WCSimBONSAI/ToolChainConfig
+++ b/configfiles/WCSimBONSAI/ToolChainConfig
@@ -1,7 +1,7 @@
 #ToolChain dynamic setup file
 
 ##### Runtime Paramiters #####
-verbose 2 ## Verbosity level of ToolChain
+verbose 4 ## Verbosity level of ToolChain
 error_level 2 # 0= do not exit, 1= exit on unhandeled errors only, 2= exit on unhandeled errors and handeled errors
 attempt_recover 1 ## 1= will attempt to finalise if an execute fails
 

--- a/configfiles/WCSimReaderTest/ToolChainConfig
+++ b/configfiles/WCSimReaderTest/ToolChainConfig
@@ -1,7 +1,7 @@
 #ToolChain dynamic setup file
 
 ##### Runtime Paramiters #####
-verbose 2 ## Verbosity level of ToolChain
+verbose 4 ## Verbosity level of ToolChain
 error_level 2 # 0= do not exit, 1= exit on unhandeled errors only, 2= exit on unhandeled errors and handeled errors
 attempt_recover 1 ## 1= will attempt to finalise if an execute fails
 

--- a/configfiles/template/ToolChainConfig
+++ b/configfiles/template/ToolChainConfig
@@ -1,7 +1,7 @@
 #ToolChain dynamic setup file
 
 ##### Runtime Paramiters #####
-verbose 1 ## Verbosity level of ToolChain
+verbose 4 ## Verbosity level of ToolChain
 error_level 0 # 0= do not exit, 1= exit on unhandeled errors only, 2= exit on unhandeled errors and handeled errors
 attempt_recover 1 ## 1= will attempt to finalise if an execute fails
 remote_port 24002

--- a/configfiles/test/ToolChainConfig
+++ b/configfiles/test/ToolChainConfig
@@ -1,7 +1,7 @@
 #ToolChain dynamic setup file
 
 ##### Runtime Paramiters #####
-verbose 1 ## Verbosity level of ToolChain
+verbose 4 ## Verbosity level of ToolChain
 error_level 0 # 0= do not exit, 1= exit on unhandeled errors only, 2= exit on unhandeled errors and handeled errors
 attempt_recover 1 ## 1= will attempt to finalise if an execute fails
 


### PR DESCRIPTION
It's a lot easier to debug when the printed output of each tool is separated out by tool. Setting toolchain verbosities to 4 (or more) does that